### PR TITLE
calculate biggest bounding box of all text fields in node

### DIFF
--- a/src/graph/graph.component.ts
+++ b/src/graph/graph.component.ts
@@ -348,14 +348,26 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnDest
         } else {
           // calculate the width
           if (nativeElement.getElementsByTagName('text').length) {
-            let textDims;
-            try {
-              textDims = nativeElement.getElementsByTagName('text')[0].getBBox();
-            } catch (ex) {
+          let maxTextDims;
+          try {
+            for (let textElem of nativeElement.getElementsByTagName('text')) {
+              let currentBBox = textElem.getBBox();
+              if (!maxTextDims) {
+                maxTextDims = currentBBox;
+              } else {
+                if (currentBBox.width > maxTextDims.width) {
+                  maxTextDims.width = currentBBox.width;
+                }
+                if (currentBBox.height > maxTextDims.height) {
+                  maxTextDims.height = currentBBox.height;
+                }
+              }
+            }
+          } catch (ex) {
               // Skip drawing if element is not displayed - Firefox would throw an error here
               return;
             }
-            node.width = textDims.width + 20;
+            node.width = maxTextDims.width + 20;
           } else {
             node.width = dims.width;
           }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The first text child of a node rect is used to calculate the node's width


**What is the new behavior?**
The widest text child of a node rect is used to calculate the node's width, allowing for multiple text fields inside a node's template that won't overflow


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
