### PR TITLE
Added missing line class to the edge path element that prevented lines to be rendered

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This library is focused on handling graph data (anything with nodes and edges) r
   <ng-template #linkTemplate let-link>
     <svg:g class="edge">
       <svg:path
+        class="line"
         stroke-width="2"
         marker-end="url(#arrow)" >
       </svg:path>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
In the current Readme the edge path element doesn't have a proper class. 
Using this markup doesn't cause any exceptions but the edges of the graph will not be rendered. 


**What is the new behavior?**
Added `class="line"` to fix the problem.
The edges are now rendered properly.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
No breaking change.

**Other information**:
