### PR TITLE
Giving option that all single nodes will be in matrix instead of long row or column

### DIFF
--- a/src/graph/graph.component.ts
+++ b/src/graph/graph.component.ts
@@ -182,6 +182,7 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnDest
   @Input() zoomToNode$: Observable<any>;
 
   @Input() dagreLayout: DagreLayout = defaultDagreLayout;
+  @Input() singleNodesPerLine: number = 1;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
@@ -424,6 +425,41 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnDest
       });
     }
 
+    if (this.singleNodesPerLine > 1) {
+      let singleNodesAmount: number  = 0;
+      let currentDestinationNode;
+      const components = dagre.graphlib.alg.components(this.graph);
+      for (let i = 0; i < components.length; i++) {
+        if (components[i].length > 1) {
+          continue;
+        }
+
+        singleNodesAmount++;
+        singleNodesAmount = singleNodesAmount % this.singleNodesPerLine;
+
+        // Starting a new nodes row by adding a new temp node
+        if (singleNodesAmount === 1) {
+          currentDestinationNode = {
+            id: id(),
+            width: 20,
+            height: 30,
+          };
+
+          this.graph.setNode(currentDestinationNode.id, currentDestinationNode);
+        }
+
+        // Finding the single node element
+        const removedNodeId: string = components[i][0];
+        const currentSourceNode = this._nodes.find(n => n.id === removedNodeId);
+
+        // Connecting it to the last node in the row.
+        this.graph.setEdge(currentSourceNode.id, currentDestinationNode.id);
+
+        // Update last node in the row
+        currentDestinationNode = currentSourceNode;
+      }
+    }
+
     // Dagre to recalc the layout
     dagre.layout(this.graph);
 
@@ -446,6 +482,11 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnDest
       let oldLink = this._oldLinks.find(ol => `${ol.source}${ol.target}` === normKey);
       if (!oldLink) {
         oldLink = this._links.find(nl => `${nl.source}${nl.target}` === normKey);
+      }
+
+      // This is for supporting multiple single nodes in a row
+      if (!oldLink) {
+        continue;
       }
 
       oldLink.oldLine = oldLink.line;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

Nodes without any links are organized by a long row or column with dagre.
This commit gives an option to set all the single nodes as a matrix for better view.

The user can decide the amount of nodes per row.