### PR TITLE
Added fade animation when adding new nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@angular/animations": "^7.1.0",
     "@angular/common": "^7.1.0",
     "@angular/compiler": "^7.1.0",
     "@angular/core": "^7.1.0",
@@ -63,6 +62,9 @@
     "@angular/compiler-cli": "^7.2.11",
     "@angular/language-service": "^7.1.0",
     "@swimlane/prettier-config-swimlane": "^1.0.0",
+    "@types/d3-selection": "^1.4.1",
+    "@types/d3-shape": "^1.3.1",
+    "@types/d3-transition": "^1.1.4",
     "@types/jasmine": "~2.8.6",
     "@types/jasminewd2": "~2.0.3",
     "@types/mdast": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@angular/animations": "^7.1.0",
     "@angular/common": "^7.1.0",
     "@angular/compiler": "^7.1.0",
     "@angular/core": "^7.1.0",

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -552,17 +552,19 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
       if (edge) {
         const linkSelection = select(linkEl.nativeElement).select('.line');
         linkSelection
-          .attr('d', edge.oldLine)
+          .attr('d', edge.line)
+          .style('opacity', 0)
           .transition()
           .duration(_animate ? 500 : 0)
-          .attr('d', edge.line);
+          .style('opacity', 1);
 
-        const textPathSelection = select(this.chartElement.nativeElement).select(`#${edge.id}`);
+        const textPathSelection = select(linkEl.nativeElement).select('.edge-label');
         textPathSelection
-          .attr('d', edge.oldTextPath)
+          .attr('d', edge.textPath)
+          .style('opacity', 0)
           .transition()
           .duration(_animate ? 500 : 0)
-          .attr('d', edge.textPath);
+          .style('opacity', 1);
       }
     });
   }

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -238,7 +238,6 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
       }
     }
     if (links) {
-      console.log(links);
       if (links.isFirstChange()) {
         this.edgePreviousArray = links.currentValue;
       } else {

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -461,7 +461,10 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
       this.center();
     }
 
-    requestAnimationFrame(() => this.redrawLines());
+    requestAnimationFrame(() => {
+      this.redrawNodes();
+      this.redrawLines();
+    });
     this.cd.markForCheck();
   }
 
@@ -560,6 +563,21 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
           .transition()
           .duration(_animate ? 500 : 0)
           .attr('d', edge.textPath);
+      }
+    });
+  }
+  
+  redrawNodes(_animate = true): void {
+    this.nodeElements.map(nodeEl => {
+      const node = this.graph.nodes.find(nod => nod.id === nodeEl.nativeElement.id);
+
+      if (node) {
+        const nodeSelection = select(nodeEl.nativeElement).select('.node');
+        nodeSelection
+          .style('opacity', 0)
+          .transition()
+          .style('opacity', 1)
+          .duration(_animate ? 500 : 0)
       }
     });
   }

--- a/projects/swimlane/ngx-graph/src/lib/models/edge.model.ts
+++ b/projects/swimlane/ngx-graph/src/lib/models/edge.model.ts
@@ -13,5 +13,6 @@ export interface Edge {
   oldLine?: any;
   oldTextPath?: string;
   textPath?: string;
-  midPoint?: NodePosition
+  midPoint?: NodePosition;
+  newLine?: boolean;
 }

--- a/projects/swimlane/ngx-graph/src/lib/models/node.model.ts
+++ b/projects/swimlane/ngx-graph/src/lib/models/node.model.ts
@@ -16,8 +16,9 @@ export interface Node {
   label?: string;
   data?: any;
   meta?: any;
+  newNode?: boolean;
 }
 
 export interface ClusterNode extends Node {
-  childNodeIds: string[];
+  childNodeIds?: string[];
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [X] Feature
- [X] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When adding new nodes/links, we don't get a fadeInOut Animation for those nodes, instead, we get the entire graph reloaded.


**What is the new behavior?**
Adding nodes/links have a nice fadeInOut Animation as requested in #4 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No
