### PR TITLE
Adding a custom curve demo + create demo components folder

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,7 +23,8 @@ import { environment } from 'src/environments/environment';
     RuntimeContentModule.forRoot({
       imports: [
         NgxGraphModule, 
-        NgxChartsModule
+        NgxChartsModule,
+        DemoModule
       ]
     }),
     DocsifyPluginsModule,

--- a/src/docs/demos/components/ngx-graph-custom-curve/customDagreNodesOnly.ts
+++ b/src/docs/demos/components/ngx-graph-custom-curve/customDagreNodesOnly.ts
@@ -1,0 +1,180 @@
+import { Graph, Layout, Edge } from '@swimlane/ngx-graph';
+import * as dagre from 'dagre';
+
+export enum Orientation {
+  LEFT_TO_RIGHT = 'LR',
+  RIGHT_TO_LEFT = 'RL',
+  TOP_TO_BOTTOM = 'TB',
+  BOTTOM_TO_TOM = 'BT'
+}
+export enum Alignment {
+  CENTER = 'C',
+  UP_LEFT = 'UL',
+  UP_RIGHT = 'UR',
+  DOWN_LEFT = 'DL',
+  DOWN_RIGHT = 'DR'
+}
+
+export interface DagreSettings {
+  orientation?: Orientation;
+  marginX?: number;
+  marginY?: number;
+  edgePadding?: number;
+  rankPadding?: number;
+  nodePadding?: number;
+  align?: Alignment;
+  acyclicer?: 'greedy' | undefined;
+  ranker?: 'network-simplex' | 'tight-tree' | 'longest-path';
+  multigraph?: boolean;
+  compound?: boolean;
+}
+
+export interface DagreNodesOnlySettings extends DagreSettings {
+  curveDistance?: number;
+}
+
+const DEFAULT_EDGE_NAME = '\x00';
+const GRAPH_NODE = '\x00';
+const EDGE_KEY_DELIM = '\x01';
+
+export class DagreNodesOnlyLayout implements Layout {
+  defaultSettings: DagreNodesOnlySettings = {
+    orientation: Orientation.LEFT_TO_RIGHT,
+    marginX: 20,
+    marginY: 20,
+    edgePadding: 100,
+    rankPadding: 100,
+    nodePadding: 50,
+    curveDistance: 20,
+    multigraph: false,
+    compound: true
+  };
+  settings: DagreNodesOnlySettings = {};
+
+  dagreGraph: any;
+  dagreNodes: any;
+  dagreEdges: any;
+
+  public run(graph: Graph): Graph {
+    this.createDagreGraph(graph);
+    dagre.layout(this.dagreGraph);
+
+    graph.edgeLabels = this.dagreGraph._edgeLabels;
+
+    for (const dagreNodeId in this.dagreGraph._nodes) {
+      const dagreNode = this.dagreGraph._nodes[dagreNodeId];
+      const node = graph.nodes.find(n => n.id === dagreNode.id);
+      node.position = {
+        x: dagreNode.x,
+        y: dagreNode.y
+      };
+      node.dimension = {
+        width: dagreNode.width,
+        height: dagreNode.height
+      };
+    }
+    for (const edge of graph.edges) {
+      this.updateEdge(graph, edge);
+    }
+
+    return graph;
+  }
+
+  public updateEdge(graph: Graph, edge: Edge): Graph {
+    const sourceNode = graph.nodes.find(n => n.id === edge.source);
+    const targetNode = graph.nodes.find(n => n.id === edge.target);
+    const rankAxis: 'x' | 'y' = this.settings.orientation === 'BT' || this.settings.orientation === 'TB' ? 'y' : 'x';
+    const orderAxis: 'x' | 'y' = rankAxis === 'y' ? 'x' : 'y';
+    const rankDimension = rankAxis === 'y' ? 'height' : 'width';
+    // determine new arrow position
+    const dir = sourceNode.position[rankAxis] <= targetNode.position[rankAxis] ? -1 : 1;
+    const startingPoint = {
+      [orderAxis]: sourceNode.position[orderAxis],
+      [rankAxis]: sourceNode.position[rankAxis] - dir * (sourceNode.dimension[rankDimension] / 2)
+    };
+    const endingPoint = {
+      [orderAxis]: targetNode.position[orderAxis],
+      [rankAxis]: targetNode.position[rankAxis] + dir * (targetNode.dimension[rankDimension] / 2)
+    };
+
+    const curveDistance = this.settings.curveDistance || this.defaultSettings.curveDistance;
+    // generate new points
+    edge.points = [
+      startingPoint,
+      endingPoint
+    ];
+    const edgeLabelId = `${edge.source}${EDGE_KEY_DELIM}${edge.target}${EDGE_KEY_DELIM}${DEFAULT_EDGE_NAME}`;
+    const matchingEdgeLabel = graph.edgeLabels[edgeLabelId];
+    if (matchingEdgeLabel) {
+      matchingEdgeLabel.points = edge.points;
+    }
+    return graph;
+  }
+
+  public createDagreGraph(graph: Graph): any {
+    const settings = Object.assign({}, this.defaultSettings, this.settings);
+    this.dagreGraph = new dagre.graphlib.Graph({ compound: settings.compound, multigraph: settings.multigraph });
+    this.dagreGraph.setGraph({
+      rankdir: settings.orientation,
+      marginx: settings.marginX,
+      marginy: settings.marginY,
+      edgesep: settings.edgePadding,
+      ranksep: settings.rankPadding,
+      nodesep: settings.nodePadding,
+      align: settings.align,
+      acyclicer: settings.acyclicer,
+      ranker: settings.ranker,
+      multigraph: settings.multigraph,
+      compound: settings.compound
+    });
+
+    // Default to assigning a new object as a label for each new edge.
+    this.dagreGraph.setDefaultEdgeLabel(() => {
+      return {
+        /* empty */
+      };
+    });
+
+    this.dagreNodes = graph.nodes.map(n => {
+      const node: any = Object.assign({}, n);
+      node.width = n.dimension.width;
+      node.height = n.dimension.height;
+      node.x = n.position.x;
+      node.y = n.position.y;
+      return node;
+    });
+
+    this.dagreEdges = graph.edges.map(l => {
+	    let linkId: number = 1;
+      const newLink: any = Object.assign({}, l);
+      if (!newLink.id) {
+        newLink.id = 'a'+linkId.toString();
+		    linkId++;
+      }
+      return newLink;
+    });
+
+    for (const node of this.dagreNodes) {
+      if (!node.width) {
+        node.width = 20;
+      }
+      if (!node.height) {
+        node.height = 30;
+      }
+
+      // update dagre
+      this.dagreGraph.setNode(node.id, node);
+    }
+
+    // update dagre
+    for (const edge of this.dagreEdges) {
+      if (settings.multigraph) {
+        this.dagreGraph.setEdge(edge.source, edge.target, edge, edge.id);
+      } else {
+        this.dagreGraph.setEdge(edge.source, edge.target);
+      }
+    }
+
+    return this.dagreGraph;
+  }
+}

--- a/src/docs/demos/components/ngx-graph-custom-curve/customStepCurved.js
+++ b/src/docs/demos/components/ngx-graph-custom-curve/customStepCurved.js
@@ -1,0 +1,76 @@
+function Step(context, t) {
+  this._context = context;
+  this._t = t;
+}
+
+Step.prototype = {
+  areaStart: function() {
+    this._line = 0;
+  },
+  areaEnd: function() {
+    this._line = NaN;
+  },
+  lineStart: function() {
+    this._x = this._y = NaN;
+    this._point = 0;
+  },
+  lineEnd: function() {
+    if (0 < this._t && this._t < 1 && this._point === 2) this._context.lineTo(this._x, this._y);
+    if (this._line || (this._line !== 0 && this._point === 1)) this._context.closePath();
+    if (this._line >= 0) this._t = 1 - this._t, this._line = 1 - this._line;
+  },
+  point: function(x, y) {
+    x = +x, y = +y;
+    switch (this._point) {
+      case 0:
+      case 0:
+        this._point = 1;
+        this._line ? this._context.lineTo(x, y) : this._context.moveTo(x, y);
+        break;
+      case 1:
+        this._point = 2; // proceed
+      default:
+        {
+          var xN, yN, mYb, mYa;
+          if (this._t <= 0) {
+            xN = Math.abs(x - this._x) * 0.25;
+            yN = Math.abs(y - this._y) * 0.25;
+            mYb = (this._y < y) ? this._y + yN : this._y - yN;
+            mYa = (this._y > y) ? y + yN : y - yN;
+
+            this._context.quadraticCurveTo(this._x, this._y, this._x, mYb);
+            this._context.lineTo(this._x, mYa);
+            this._context.quadraticCurveTo(this._x, y, this._x + xN, y);
+            this._context.lineTo(x - xN, y);
+
+          } else {
+            var x1 = this._x * (1 - this._t) + x * this._t;
+
+            xN = Math.abs(x - x1) * 0.25;
+            yN = Math.abs(y - this._y) * 0.25;
+            mYb = (this._y < y) ? this._y + yN : this._y - yN;
+            mYa = (this._y > y) ? y + yN : y - yN;
+
+            this._context.quadraticCurveTo(x1, this._y, x1, mYb);
+            this._context.lineTo(x1, mYa);
+            this._context.quadraticCurveTo(x1, y, x1 + xN, y);
+            this._context.lineTo(x - xN, y);
+          }
+          break;
+        }
+    }
+    this._x = x, this._y = y;
+  }
+};
+
+stepRound = function(context) {
+  return new Step(context, 0.5);
+};
+
+stepRoundBefore = function(context) {
+  return new Step(context, 0);
+};
+
+stepRoundAfter = function(context) {
+  return new Step(context, 1);
+};

--- a/src/docs/demos/components/ngx-graph-custom-curve/ngx-graph-custom-curve.component.html
+++ b/src/docs/demos/components/ngx-graph-custom-curve/ngx-graph-custom-curve.component.html
@@ -1,0 +1,9 @@
+<ngx-graph
+  class="chart-container"
+  [view]="[500, 300]"
+  [links]="links"
+  [nodes]="nodes"
+  [layout]="layout"
+  [curve]="curve"
+  [draggingEnabled]="false">
+</ngx-graph>

--- a/src/docs/demos/components/ngx-graph-custom-curve/ngx-graph-custom-curve.component.ts
+++ b/src/docs/demos/components/ngx-graph-custom-curve/ngx-graph-custom-curve.component.ts
@@ -1,0 +1,49 @@
+import { Component } from '@angular/core';
+import { Layout, Edge, Node } from '@swimlane/ngx-graph';
+import { DagreNodesOnlyLayout } from './customDagreNodesOnly'
+import './customStepCurved';
+
+declare var stepRound;
+
+@Component({
+  selector: 'ngx-graph-custom-curve',
+  templateUrl: './ngx-graph-custom-curve.component.html',
+})
+export class NgxGraphCustomCurve {
+
+  public curve: any = stepRound;
+  public layout: Layout = new DagreNodesOnlyLayout();
+  public links: Edge[] = [
+    {
+      id: 'a',
+      source: 'first',
+      target: 'second',
+      label: 'is parent of'
+    }, {
+      id: 'b',
+      source: 'first',
+      target: 'third',
+      label: 'custom label'
+    }, {
+      id: 'c',
+      source: 'first',
+      target: 'fourth',
+      label: 'custom label'
+    }
+  ];
+  public nodes: Node[] =[
+    {
+      id: 'first',
+      label: 'A'
+    }, {
+      id: 'second',
+      label: 'B'
+    }, {
+      id: 'third',
+      label: 'C'
+    }, {
+      id: 'fourth',
+      label: 'D'
+    }
+  ];
+}

--- a/src/docs/demos/demo.module.ts
+++ b/src/docs/demos/demo.module.ts
@@ -1,7 +1,15 @@
 import { NgModule } from '@angular/core';
 import { BaseModule } from './base/base.module';
+import { NgxGraphCustomCurve } from './components/ngx-graph-custom-curve/ngx-graph-custom-curve.component';
+import { NgxGraphModule } from '@swimlane/ngx-graph';
 
 @NgModule({
-  imports: [BaseModule]
+  imports: [BaseModule,
+    NgxGraphModule
+  ],
+  declarations: [NgxGraphCustomCurve],
+  exports: [
+    NgxGraphCustomCurve
+  ],
 })
 export class DemoModule {}

--- a/src/docs/demos/interactive-demo.md
+++ b/src/docs/demos/interactive-demo.md
@@ -40,6 +40,12 @@ export class MyComponent{
 <ngx-graph ... [curve]="curve"> </ngx-graph>
 ```
 
+## Add Custom Curve
+
+```html { playground }
+<ngx-graph-custom-curve></ngx-graph-custom-curve>
+```
+
 ## Triggering Update
 
 The graph component updates itself on every input change. The inputs are immutable, so in order to trigger the update, you would need to pass a new object instance.


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ X] No

This commit adds a new section inside the interactive demo documentation for an example of custom curve. The commit add a new components section inside the demo module in order to be able to use the controller and functionality inside the demos and not just basing the code on html only.

A few notes:
1. Please note that dragging is disabled. This is a result of a bug that I found when using a custom layout and curve (that comes from outside ngx-graph).
This issue will be handled on different PR.

2. Please update if the new location for the component folder (for demos) is the right place.

3. Text and explanation will be added later in a separate review in order to be able to review the text from content and grammar aspects.

![image](https://user-images.githubusercontent.com/33118325/57968016-c8df8a00-796d-11e9-8c06-1df0576c262b.png)
