### PR TITLE
Adding New template section with organization tree example, fix bug and enable dragging.

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -410,8 +410,13 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
 
       const normKey = edgeLabelId.replace(/[^\w-]*/g, '');
 
-      let oldLink = this._oldLinks.find(ol => `${ol.source}${ol.target}${ol.id}` === normKey);
-      let linkFromGraph = this.graph.edges.find(nl => `${nl.source}${nl.target}${nl.id}` === normKey);
+      const isMultigraph = this.layout && typeof this.layout !== 'string' && this.layout.settings && this.layout.settings.multigraph;
+
+      let oldLink = isMultigraph ? this._oldLinks.find(ol => `${ol.source}${ol.target}${ol.id}` === normKey) :
+                                      this._oldLinks.find(ol => `${ol.source}${ol.target}` === normKey);  
+
+      const linkFromGraph = isMultigraph ? this.graph.edges.find(nl => `${nl.source}${nl.target}${nl.id}` === normKey) :
+                                            this.graph.edges.find(nl => `${nl.source}${nl.target}` === normKey);  
       
       if (!oldLink) {
         oldLink = linkFromGraph || edgeLabel;

--- a/src/docs/demos/components/ngx-graph-custom-curve/ngx-graph-custom-curve.component.html
+++ b/src/docs/demos/components/ngx-graph-custom-curve/ngx-graph-custom-curve.component.html
@@ -4,6 +4,5 @@
   [links]="links"
   [nodes]="nodes"
   [layout]="layout"
-  [curve]="curve"
-  [draggingEnabled]="false">
+  [curve]="curve">
 </ngx-graph>

--- a/src/docs/demos/components/ngx-graph-org-tree/customDagreNodesOnly.ts
+++ b/src/docs/demos/components/ngx-graph-org-tree/customDagreNodesOnly.ts
@@ -1,0 +1,188 @@
+import { Graph, Layout, Edge } from '@swimlane/ngx-graph';
+import * as dagre from 'dagre';
+
+export enum Orientation {
+  LEFT_TO_RIGHT = 'LR',
+  RIGHT_TO_LEFT = 'RL',
+  TOP_TO_BOTTOM = 'TB',
+  BOTTOM_TO_TOM = 'BT'
+}
+export enum Alignment {
+  CENTER = 'C',
+  UP_LEFT = 'UL',
+  UP_RIGHT = 'UR',
+  DOWN_LEFT = 'DL',
+  DOWN_RIGHT = 'DR'
+}
+
+export interface DagreSettings {
+  orientation?: Orientation;
+  marginX?: number;
+  marginY?: number;
+  edgePadding?: number;
+  rankPadding?: number;
+  nodePadding?: number;
+  align?: Alignment;
+  acyclicer?: 'greedy' | undefined;
+  ranker?: 'network-simplex' | 'tight-tree' | 'longest-path';
+  multigraph?: boolean;
+  compound?: boolean;
+}
+
+export interface DagreNodesOnlySettings extends DagreSettings {
+  curveDistance?: number;
+}
+
+const DEFAULT_EDGE_NAME = '\x00';
+const GRAPH_NODE = '\x00';
+const EDGE_KEY_DELIM = '\x01';
+
+export class DagreNodesOnlyLayout implements Layout {
+  defaultSettings: DagreNodesOnlySettings = {
+    orientation: Orientation.LEFT_TO_RIGHT,
+    marginX: 20,
+    marginY: 20,
+    edgePadding: 100,
+    rankPadding: 100,
+    nodePadding: 50,
+    curveDistance: 20,
+    multigraph: false,
+    compound: true
+  };
+  settings: DagreNodesOnlySettings = {};
+
+  dagreGraph: any;
+  dagreNodes: any;
+  dagreEdges: any;
+
+  public run(graph: Graph): Graph {
+    this.createDagreGraph(graph);
+    dagre.layout(this.dagreGraph);
+
+    graph.edgeLabels = this.dagreGraph._edgeLabels;
+
+    for (const dagreNodeId in this.dagreGraph._nodes) {
+      const dagreNode = this.dagreGraph._nodes[dagreNodeId];
+      const node = graph.nodes.find(n => n.id === dagreNode.id);
+      node.position = {
+        x: dagreNode.x,
+        y: dagreNode.y
+      };
+      node.dimension = {
+        width: dagreNode.width,
+        height: dagreNode.height
+      };
+    }
+    for (const edge of graph.edges) {
+      this.updateEdge(graph, edge);
+    }
+
+    return graph;
+  }
+
+  public updateEdge(graph: Graph, edge: Edge): Graph {
+    const sourceNode = graph.nodes.find(n => n.id === edge.source);
+    const targetNode = graph.nodes.find(n => n.id === edge.target);
+    const rankAxis: 'x' | 'y' = this.settings.orientation === 'BT' || this.settings.orientation === 'TB' ? 'y' : 'x';
+    const orderAxis: 'x' | 'y' = rankAxis === 'y' ? 'x' : 'y';
+    const rankDimension = rankAxis === 'y' ? 'height' : 'width';
+    // determine new arrow position
+    const dir = sourceNode.position[rankAxis] <= targetNode.position[rankAxis] ? -1 : 1;
+    const startingPoint = {
+      [orderAxis]: sourceNode.position[orderAxis],
+      [rankAxis]: sourceNode.position[rankAxis] - dir * (sourceNode.dimension[rankDimension] / 2)
+    };
+    const endingPoint = {
+      [orderAxis]: targetNode.position[orderAxis],
+      [rankAxis]: targetNode.position[rankAxis] + dir * (targetNode.dimension[rankDimension] / 2)
+    };
+
+    const curveDistance = this.settings.curveDistance || this.defaultSettings.curveDistance;
+    // generate new points
+    edge.points = [
+      startingPoint,
+      {
+        [rankAxis]: (startingPoint[rankAxis] + endingPoint[rankAxis]) / 2,
+        [orderAxis]: startingPoint[orderAxis]
+      },
+      {
+        [orderAxis]: endingPoint[orderAxis],
+        [rankAxis]: (startingPoint[rankAxis] + endingPoint[rankAxis]) / 2,
+      },
+      endingPoint
+    ];
+    const edgeLabelId = `${edge.source}${EDGE_KEY_DELIM}${edge.target}${EDGE_KEY_DELIM}${DEFAULT_EDGE_NAME}`;
+    const matchingEdgeLabel = graph.edgeLabels[edgeLabelId];
+    if (matchingEdgeLabel) {
+      matchingEdgeLabel.points = edge.points;
+    }
+    return graph;
+  }
+
+  public createDagreGraph(graph: Graph): any {
+    const settings = Object.assign({}, this.defaultSettings, this.settings);
+    this.dagreGraph = new dagre.graphlib.Graph({ compound: settings.compound, multigraph: settings.multigraph });
+    this.dagreGraph.setGraph({
+      rankdir: settings.orientation,
+      marginx: settings.marginX,
+      marginy: settings.marginY,
+      edgesep: settings.edgePadding,
+      ranksep: settings.rankPadding,
+      nodesep: settings.nodePadding,
+      align: settings.align,
+      acyclicer: settings.acyclicer,
+      ranker: settings.ranker,
+      multigraph: settings.multigraph,
+      compound: settings.compound
+    });
+
+    // Default to assigning a new object as a label for each new edge.
+    this.dagreGraph.setDefaultEdgeLabel(() => {
+      return {
+        /* empty */
+      };
+    });
+
+    this.dagreNodes = graph.nodes.map(n => {
+      const node: any = Object.assign({}, n);
+      node.width = n.dimension.width;
+      node.height = n.dimension.height;
+      node.x = n.position.x;
+      node.y = n.position.y;
+      return node;
+    });
+
+    this.dagreEdges = graph.edges.map(l => {
+	  let linkId: number = 1;
+      const newLink: any = Object.assign({}, l);
+      if (!newLink.id) {
+        newLink.id = linkId;
+		    linkId++;
+      }
+      return newLink;
+    });
+
+    for (const node of this.dagreNodes) {
+      if (!node.width) {
+        node.width = 20;
+      }
+      if (!node.height) {
+        node.height = 30;
+      }
+
+      // update dagre
+      this.dagreGraph.setNode(node.id, node);
+    }
+
+    // update dagre
+    for (const edge of this.dagreEdges) {
+      if (settings.multigraph) {
+        this.dagreGraph.setEdge(edge.source, edge.target, edge, edge.id);
+      } else {
+        this.dagreGraph.setEdge(edge.source, edge.target);
+      }
+    }
+
+    return this.dagreGraph;
+  }
+}

--- a/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.html
+++ b/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.html
@@ -1,0 +1,41 @@
+<ngx-graph
+[view]="[800, 500]"
+[links]="links"
+[nodes]="nodes"
+[curve]="curve"
+[layout]="layout"
+[nodeWidth]=150
+[nodeHeight]=100
+[layoutSettings]="layoutSettings"
+[curve]="curve"
+[enableZoom]="true"
+[autoZoom]="true">
+
+<ng-template #defsTemplate>
+  <svg:marker id="arrow" viewBox="0 -5 10 10" refX="8" refY="0" markerWidth="4" markerHeight="4" orient="auto">
+    <svg:path d="M0,-5L10,0L0,5" class="arrow-head" />
+  </svg:marker>
+</ng-template>
+
+<ng-template #nodeTemplate let-node>
+  <svg:g class="node" xmlns="http://www.w3.org/2000/xhtml" width="150" height="100">
+    <svg:foreignObject width="150" height="100">
+      <xhtml:div class="cardContainer" xmlns="http://www.w3.org/1999/xhtml" [ngStyle]=getStyles(node)>
+        <label class="name">{{node.label}}</label>
+        <label>{{node.data.role}}</label>
+        <label>{{node.data.office}}</label>
+      </xhtml:div>
+    </svg:foreignObject>
+  </svg:g>
+</ng-template>
+
+<ng-template #linkTemplate let-link>
+  <svg:g class="edge">
+    <svg:path class="line" stroke-width="2" marker-end="url(#arrow)">
+    </svg:path>
+    <svg:text class="edge-label" text-anchor="middle">
+      <textPath class="text-path" [attr.href]="'#' + link.id" [style.dominant-baseline]="link.dominantBaseline" startOffset="50%">{{link.label}}</textPath>
+    </svg:text>
+  </svg:g>
+</ng-template>
+</ngx-graph>

--- a/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.scss
+++ b/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.scss
@@ -1,0 +1,23 @@
+:host ::ng-deep {
+    display: block;
+    height: inherit;
+    width: inherit;
+
+    .cardContainer {
+        height: 100;
+        width: 150;
+        display: block;
+
+        .name {
+            font-size: 24px;
+        }
+
+        label {
+            display: block;
+            text-align: center;
+            font-size: 20px;
+            margin-top: 4px;
+            margin-bottom: 8px;
+        }
+    }
+}

--- a/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.spec.ts
+++ b/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NgxGraphOrgTreeComponent } from './ngx-graph-org-tree.component';
+
+describe('NgxGraphOrgTreeComponent', () => {
+  let component: NgxGraphOrgTreeComponent;
+  let fixture: ComponentFixture<NgxGraphOrgTreeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NgxGraphOrgTreeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NgxGraphOrgTreeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.ts
+++ b/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.ts
@@ -1,0 +1,105 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { Edge, Node, Layout } from '@swimlane/ngx-graph';
+import { DagreNodesOnlyLayout } from './customDagreNodesOnly'
+import * as shape from 'd3-shape';
+
+export class Employee {
+  id: string;
+  name: string;
+  office: string;
+  role: string;
+  backgroundColor: string;
+  upperManagerId?: string;
+}
+
+@Component({
+  selector: 'ngx-graph-org-tree',
+  templateUrl: './ngx-graph-org-tree.component.html',
+  styleUrls: ['./ngx-graph-org-tree.component.scss']
+})
+export class NgxGraphOrgTreeComponent implements OnInit {
+
+  @Input() employees: Employee[] = [];
+
+  public nodes: Node[] = [];
+  public links: Edge[] = [];
+  public layoutSettings = {
+    orientation: "TB"
+  }
+  public curve: any = shape.curveLinear;
+  public layout: Layout = new DagreNodesOnlyLayout();
+
+  constructor() {
+    this.employees = [{
+      id: "1",
+      name: "Employee 1",
+      office: "Office 1",
+      role: "Manager",
+      backgroundColor: "#DC143C",
+    }, {
+      id: "2",
+      name: "Employee 2",
+      office: "Office 2",
+      role: "Engineer",
+      backgroundColor: "#00FFFF",
+      upperManagerId: "1",
+    }, {
+      id: "3",
+      name: "Employee 3",
+      office: "Office 3",
+      role: "Engineer",
+      backgroundColor: "#00FFFF",
+      upperManagerId: "1",
+    }, {
+      id: "4",
+      name: "Employee 4",
+      office: "Office 4",
+      role: "Engineer",
+      backgroundColor: "#00FFFF",
+      upperManagerId: "1",
+    }, {
+      id: "5",
+      name: "Employee 5",
+      office: "Office 5",
+      role: "Student",
+      backgroundColor: "#8A2BE2",
+      upperManagerId: "4",
+    }];
+  }
+
+  public ngOnInit(): void {
+    for (const employee of this.employees) {
+      const node: Node =   {
+        id: employee.id,
+        label: employee.name,
+        data: {
+          office: employee.office,
+          role: employee.role,
+          backgroundColor: employee.backgroundColor
+        }
+      };
+
+      this.nodes.push(node);
+    }
+
+    for (const employee of this.employees) {
+      if (!employee.upperManagerId) {
+        continue;
+      }
+
+      const edge: Edge =   {
+        source: employee.upperManagerId,
+        target: employee.id,
+        label: ''
+      }
+
+      this.links.push(edge);
+    }
+  }
+
+  public getStyles(node: Node): any {
+    return {
+         "background-color": node.data.backgroundColor,
+    }
+  }
+}

--- a/src/docs/demos/demo.module.ts
+++ b/src/docs/demos/demo.module.ts
@@ -1,15 +1,22 @@
 import { NgModule } from '@angular/core';
 import { BaseModule } from './base/base.module';
+import { CommonModule } from '@angular/common';
 import { NgxGraphCustomCurve } from './components/ngx-graph-custom-curve/ngx-graph-custom-curve.component';
+import { NgxGraphOrgTreeComponent } from './components/ngx-graph-org-tree/ngx-graph-org-tree.component';
 import { NgxGraphModule } from '@swimlane/ngx-graph';
 
 @NgModule({
   imports: [BaseModule,
+    CommonModule,
     NgxGraphModule
   ],
-  declarations: [NgxGraphCustomCurve],
+  declarations: [
+    NgxGraphCustomCurve,
+    NgxGraphOrgTreeComponent
+  ],
   exports: [
-    NgxGraphCustomCurve
+    NgxGraphCustomCurve,
+    NgxGraphOrgTreeComponent
   ],
 })
 export class DemoModule {}

--- a/src/docs/demos/interactive-demo.md
+++ b/src/docs/demos/interactive-demo.md
@@ -138,3 +138,11 @@ export class MyComponent{
 ```html
 <ngx-graph ... [zoomToFit$]="zoomToFit$"> </ngx-graph>
 ```
+
+# Templates Example
+
+## Organization Tree
+
+```html { playground }
+<ngx-graph-org-tree></ngx-graph-org-tree>
+```


### PR DESCRIPTION
1. Adding new template section for graphs examples that build on ngx-graph.
2. Adding an organization tree graph based on ngx-graph.
3. Fix a bug of multi graph with layouts.
4. Adding a dragging functionality to the custom curve example

Documentation text will be added later in a separate review.

![image](https://user-images.githubusercontent.com/33118325/58039088-68ea0e80-7b3a-11e9-8b44-f6c637c4a969.png)
