### PR TITLE
Update midpoint UI to be updated on drag + update org tree example with midpoint

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -438,16 +438,7 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
       newLink.line = line;
       newLink.points = points;
 
-      if (points.length % 2 === 1) {
-        newLink.midPoint = points[Math.floor(points.length / 2)];
-      } else {
-        const first = points[points.length / 2];
-        const second = points[points.length / 2 - 1];
-        newLink.midPoint = {
-          x: (first.x + second.x) / 2,
-          y: (first.y + second.y) / 2
-        };
-      }
+      this.updateMidpointOnEdge(newLink, points);
 
       const textPos = points[Math.floor(points.length / 2)];
       if (textPos) {
@@ -590,6 +581,8 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
           .ease(ease.easeSinInOut)
           .duration(_animate ? 500 : 0)
           .attr('d', edge.textPath);
+
+        this.updateMidpointOnEdge(edge, edge.points);
       }
     });
   }
@@ -1024,6 +1017,19 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
       default:
         this.onPan(event);
         break;
+    }
+  }
+
+  private updateMidpointOnEdge(edge: Edge, points: any): void {
+    if (points.length % 2 === 1) {
+      edge.midPoint = points[Math.floor(points.length / 2)];
+    } else {
+      const first = points[points.length / 2];
+      const second = points[points.length / 2 - 1];
+      edge.midPoint = {
+        x: (first.x + second.x) / 2,
+        y: (first.y + second.y) / 2
+      };
     }
   }
 }

--- a/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.html
+++ b/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.html
@@ -37,5 +37,10 @@
       <textPath class="text-path" [attr.href]="'#' + link.id" [style.dominant-baseline]="link.dominantBaseline" startOffset="50%">{{link.label}}</textPath>
     </svg:text>
   </svg:g>
+  <svg:g class="linkMidpoint" *ngIf="link.midPoint"
+         [attr.transform]="'translate(' + (link.midPoint.x) + ',' + (link.midPoint.y) + ')'">
+    <ellipse rx="30" ry="10" />
+    <svg:text alignment-baseline="central">{{ link.data.linkText }}</svg:text>
+</svg:g>
 </ng-template>
 </ngx-graph>

--- a/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.scss
+++ b/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.scss
@@ -20,4 +20,19 @@
             margin-bottom: 8px;
         }
     }
+
+    .linkMidpoint {
+        ellipse {
+          fill:white;
+          stroke: black;
+          stroke-width: 1;
+        }
+    
+        text {
+          stroke: transparent;
+          fill:black;
+          text-anchor: middle; 
+          font-size: 10px;
+        }
+      }
 }

--- a/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.ts
+++ b/src/docs/demos/components/ngx-graph-org-tree/ngx-graph-org-tree.component.ts
@@ -90,7 +90,10 @@ export class NgxGraphOrgTreeComponent implements OnInit {
       const edge: Edge =   {
         source: employee.upperManagerId,
         target: employee.id,
-        label: ''
+        label: '',
+        data: {
+          linkText: 'Manager of'
+        }
       }
 
       this.links.push(edge);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

Support in midpoint UI dragging after setting midpoint UI - the problem is that we don't update the mid point on each drag based on the link points.
Updated the org tree example with a midpoint UI.

In the image below, we can see how the UI was dragged with the links.

![image](https://user-images.githubusercontent.com/33118325/58562833-b5b4a000-8232-11e9-99d4-b89c9742bf85.png)
