### PR TITLE
Add parameter check for update mid point function

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -1021,6 +1021,10 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
   }
 
   private updateMidpointOnEdge(edge: Edge, points: any): void {
+    if (!edge || !points) {
+      return;
+    }
+    
     if (points.length % 2 === 1) {
       edge.midPoint = points[Math.floor(points.length / 2)];
     } else {


### PR DESCRIPTION
Due to recent change of calling updateMidpointOnEdge during the drag operation.
There is a race condition where the edge has no point.

The PR add a check for the parameters of updateMidpointOnEdge.
