### PR TITLE
Fix pan to node + add basic keyboard navigation support,

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/key-codes.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/key-codes.ts
@@ -1,0 +1,8 @@
+export class KeyboardEventNumbers {
+    public static readonly keyLeft: number = 37;
+    public static readonly keyUp: number = 38;
+    public static readonly keyRight: number = 39;
+    public static readonly keyDown: number = 40;
+    public static readonly keyPlus: number = 187;
+    public static readonly keyMinus: number = 189;
+}


### PR DESCRIPTION
Keyboard navigation using the arrows keys and plus and minus for zoom

Please note the following limitation:
The keyboard navigation will work on two graphs which are not part of the same dom tree due to the keyboard event. I think it's not relevant for most of our use cases.

In addition, this PR contains a fix for pan to node, we need to find the node from this.graph.nodes and not from this.nodes

 