### PR TITLE
fix-link-label-not-updating

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -468,6 +468,8 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
       }
 
       oldLink.oldLine = oldLink.line;
+	  
+	    oldLink.label = linkFromGraph.label || oldLink.label;
 
       const points = edgeLabel.points;
       const line = this.generateLine(points);

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -469,7 +469,7 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
 
       oldLink.oldLine = oldLink.line;
 	  
-	    oldLink.label = linkFromGraph.label || oldLink.label;
+	    oldLink.label = linkFromGraph.label ?? oldLink.label;
 
       const points = edgeLabel.points;
       const line = this.generateLine(points);

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -469,7 +469,7 @@ export class GraphComponent extends BaseChartComponent implements OnInit, OnChan
 
       oldLink.oldLine = oldLink.line;
 	  
-	    oldLink.label = linkFromGraph.label ?? oldLink.label;
+      oldLink.label = linkFromGraph.label || oldLink.label;
 
       const points = edgeLabel.points;
       const line = this.generateLine(points);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The label is not being updated if only the "label" key in the Link object is changed. The issues #100 and #120 addressed this issue but failed to resolve it as the issue lies elsewhere.
![image](https://user-images.githubusercontent.com/19354253/95770488-60572280-0cb1-11eb-96ae-4bae9ad7c368.png)
The code marked with the red line compares the link in storage and the new link and only if the data fields are different will the graph actually do something, but the "something" it does is copy the data from the new link to the place of the old one. As the "linkFromGraph.label" was the only field to actually change from the old graph data to the new one, such change is not detected and nothing is done about it.

**What is the new behavior?**
The label now gets copied, should it exist. If the label does not exist (or is empty), it defaults back to the original label.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
