### PR TITLE
Support in msagl layout | part 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "dagre": "^0.8.4",
     "deepmerge": "^4.2.2",
     "mdast": "^3.0.0",
+    "msagl-js": "0.0.6",
     "ngx-logger": "^4.0.8",
     "path": "^0.12.7",
     "process": "^0.11.10",

--- a/src/docs/demos/components/ngx-graph-msagl/msaglLayout.ts
+++ b/src/docs/demos/components/ngx-graph-msagl/msaglLayout.ts
@@ -1,0 +1,92 @@
+import { Graph, Layout, Edge } from '@swimlane/ngx-graph';
+import {
+  GeomGraph,
+  SugiyamaLayoutSettings,
+  interpolateICurve,
+  LayeredLayout,
+  CancelToken,
+  LayerDirectionEnum
+} from 'msagl-js';
+import { Rectangle } from 'msagl-js/dist/layoutPlatform/math/geometry/rectangle';
+
+const DEFAULT_EDGE_NAME = '\x00';
+const EDGE_KEY_DELIM = '\x01';
+
+export class MSAGLLayout implements Layout {
+  public run(graph: Graph): Graph {
+    const g = this.createGeomGraph(graph);
+    const sl = new SugiyamaLayoutSettings();
+    sl.layerDirection = LayerDirectionEnum.LR;
+    sl.MinNodeHeight = 100;
+    sl.MinNodeWidth = 100;
+    const ll = new LayeredLayout(g, sl, new CancelToken());
+    ll.run();
+
+    graph.edgeLabels = [];
+
+    for (const node of g.shallowNodes()) {
+      const graphNode = graph.nodes.find(n => n.id === node.id);
+      graphNode.position = {
+        x: (node as any).center.x_,
+        y: (node as any).center.y_
+      };
+      graphNode.dimension = {
+        width: graphNode.dimension.width,
+        height: graphNode.dimension.height
+      };
+    }
+
+    const geomEdges = Array.from(g.edges());
+    for (const edge of graph.edges) {
+      this.updateGraphEdge(graph, edge, geomEdges);
+    }
+
+    return graph;
+  }
+
+  // MSAGL don't support drag
+  public updateEdge(graph: Graph, edge: Edge): Graph {
+    return graph;
+  }
+
+  public createGeomGraph(graph: Graph): GeomGraph {
+    const g = GeomGraph.mk('graph', Rectangle.mkEmpty());
+    graph.nodes.forEach(n => {
+      g.setNode(n.id, { width: n.dimension.width, height: n.dimension.height });
+    });
+
+    graph.edges.forEach(l => {
+      g.setEdge(l.source, l.target);
+    });
+
+    return g;
+  }
+
+  public updateGraphEdge(graph: Graph, edge: Edge, geomEdges: any): Graph {
+    const geoEdge = geomEdges.find(e => e.source.id === edge.source && e.target.id === edge.target);
+    edge.points = this.getPointsFromGeoEdge(geoEdge);
+
+    const edgeLabelId = `${edge.source}${EDGE_KEY_DELIM}${edge.target}${EDGE_KEY_DELIM}${DEFAULT_EDGE_NAME}`;
+    const matchingEdgeLabel = graph.edgeLabels[edgeLabelId];
+    if (matchingEdgeLabel) {
+      matchingEdgeLabel.points = edge.points;
+    } else {
+      graph.edgeLabels.set(edgeLabelId, { points: edge.points });
+    }
+    return graph;
+  }
+
+  private getPointsFromGeoEdge(e): any {
+    const result = [];
+    const points = interpolateICurve(e.curve, e.curve.end.sub(e.curve.start).length / 20);
+
+    for (let i = 0; i < points.length; i++) {
+      result.push({
+        ['y']: points[i].y,
+        ['x']: points[i].x
+      });
+    }
+
+    return result;
+  }
+}

--- a/src/docs/demos/components/ngx-graph-msagl/ngx-graph-msagl.component.html
+++ b/src/docs/demos/components/ngx-graph-msagl/ngx-graph-msagl.component.html
@@ -1,0 +1,99 @@
+<ngx-graph
+  [view]="[800, 500]"
+  [links]="[
+    {
+      id: 'a',
+      source: 'a1',
+      target: 'a2'
+    },
+    {
+      id: 'b',
+      source: 'a2',
+      target: 'a3'
+    },
+    {
+      id: 'c',
+      source: 'a2',
+      target: 'a4'
+    },
+    {
+      id: 'd',
+      source: 'a1',
+      target: 'a5'
+    },
+    {
+      id: 'e',
+      source: 'a1',
+      target: 'a4'
+    },
+    {
+      id: 'f',
+      source: 'a1',
+      target: 'a3'
+    },
+    {
+      id: 'g',
+      source: 'a4',
+      target: 'a6'
+    },
+    {
+      id: 'h',
+      source: 'a1',
+      target: 'a6'
+    },
+    {
+      id: 'i',
+      source: 'a6',
+      target: 'a7'
+    }
+  ]"
+  [nodes]="[
+    {
+      id: 'a1',
+      label: 'N1'
+    },
+    {
+      id: 'a2',
+      label: 'N2'
+    },
+    {
+      id: 'a3',
+      label: 'N3'
+    },
+    {
+      id: 'a4',
+      label: 'N4'
+    },
+    {
+      id: 'a5',
+      label: 'N5'
+    },
+    {
+      id: 'a6',
+      label: 'N6'
+    },
+    {
+      id: 'a7',
+      label: 'N7'
+    }
+  ]"
+  [layout]="layout"
+  [curve]="curve"
+  [nodeWidth]="20"
+  [nodeHeight]="20"
+  [enableZoom]="true"
+  [draggingEnabled]="false"
+  [autoZoom]="true"
+>
+  <ng-template #defsTemplate>
+    <svg:marker id="arrow" viewBox="0 -5 10 10" refX="8" refY="0" markerWidth="4" markerHeight="4" orient="auto">
+      <svg:path d="M0,-5L10,0L0,5" class="arrow-head" />
+    </svg:marker>
+  </ng-template>
+
+  <ng-template #linkTemplate let-link>
+    <svg:g class="edge">
+      <svg:path class="line" stroke-width="2" marker-end="url(#arrow)"></svg:path>
+    </svg:g>
+  </ng-template>
+</ngx-graph>

--- a/src/docs/demos/components/ngx-graph-msagl/ngx-graph-msagl.component.scss
+++ b/src/docs/demos/components/ngx-graph-msagl/ngx-graph-msagl.component.scss
@@ -1,0 +1,5 @@
+:host ::ng-deep {
+  display: block;
+  height: inherit;
+  width: inherit;
+}

--- a/src/docs/demos/components/ngx-graph-msagl/ngx-graph-msagl.component.ts
+++ b/src/docs/demos/components/ngx-graph-msagl/ngx-graph-msagl.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { Layout } from '@swimlane/ngx-graph';
+import { MSAGLLayout } from './msaglLayout';
+
+import * as shape from 'd3-shape';
+
+@Component({
+  selector: 'ngx-graph-msagl',
+  templateUrl: './ngx-graph-msagl.component.html',
+  styleUrls: ['./ngx-graph-msagl.component.scss']
+})
+export class NgxGraphMSAGLComponent {
+  public layout: Layout = new MSAGLLayout();
+  public curve: any = shape.curveBasis;
+}

--- a/src/docs/demos/demo.module.ts
+++ b/src/docs/demos/demo.module.ts
@@ -4,10 +4,11 @@ import { CommonModule } from '@angular/common';
 import { NgxGraphCustomCurve } from './components/ngx-graph-custom-curve/ngx-graph-custom-curve.component';
 import { NgxGraphOrgTreeComponent } from './components/ngx-graph-org-tree/ngx-graph-org-tree.component';
 import { NgxGraphModule } from '@swimlane/ngx-graph';
+import { NgxGraphMSAGLComponent } from './components/ngx-graph-msagl/ngx-graph-msagl.component';
 
 @NgModule({
   imports: [BaseModule, CommonModule, NgxGraphModule],
-  declarations: [NgxGraphCustomCurve, NgxGraphOrgTreeComponent],
-  exports: [NgxGraphCustomCurve, NgxGraphOrgTreeComponent]
+  declarations: [NgxGraphCustomCurve, NgxGraphOrgTreeComponent, NgxGraphMSAGLComponent],
+  exports: [NgxGraphCustomCurve, NgxGraphOrgTreeComponent, NgxGraphMSAGLComponent]
 })
 export class DemoModule {}

--- a/src/docs/layouts.md
+++ b/src/docs/layouts.md
@@ -308,6 +308,12 @@ The dagre cluster layout groups clustered nodes together into a rectangle
 ></ngx-graph>
 ```
 
+### MSAGL layout (Preview)
+
+```html { playground }
+<ngx-graph-msagl></ngx-graph-msagl>
+```
+
 ---
 
 ## Custom Layouts


### PR DESCRIPTION
Initial integration between msagl (graph layout library) and ngx-graph.
This PR adds the package of msagl and add a simple example.

The important file is msaglLayout.ts which represent the custom layout for ngx-graph.

![image](https://user-images.githubusercontent.com/33118325/126864164-1deda808-2a85-49ba-a2be-75ff529788cf.png)
