### PR TITLE
Bump mermaid from 8.13.3 to 8.13.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6196,9 +6196,9 @@
       "dev": true
     },
     "d3": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.1.1.tgz",
-      "integrity": "sha512-8zkLMwSvUAnfN9pcJDfkuxU0Nvg4RLUD0A4BZN1KxJPtlnCGzMx3xM5cRl4m8fym/Vy8rlq52tl90UF3m91OnA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.3.0.tgz",
+      "integrity": "sha512-MDRLJCMK232OJQRqGljQ/gCxtB8k3/sLKFjftMjzPB3nKVUODpdW9Rb3vcq7U8Ka5YKoZkAmp++Ur6I+6iNWIw==",
       "requires": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -6258,9 +6258,9 @@
           "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
         },
         "d3-shape": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.0.1.tgz",
-          "integrity": "sha512-HNZNEQoDhuCrDWEc/BMbF/hKtzMZVoe64TvisFLDp2Iyj0UShB/E6/lBsLlJTfBMbYgftHj90cXJ0SEitlE6Xw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.1.0.tgz",
+          "integrity": "sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==",
           "requires": {
             "d3-path": "1 - 3"
           }
@@ -6424,9 +6424,9 @@
       }
     },
     "d3-format": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.0.1.tgz",
-      "integrity": "sha512-hdL7+HBIohpgfolhBxr1KX47VMD6+vVD/oEFrxk5yhmzV2prk99EkFKYpXuhVkFpTgHdJ6/4bYcjdLPPXV4tIA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
     },
     "d3-geo": {
       "version": "3.0.1",
@@ -6437,9 +6437,9 @@
       }
     },
     "d3-hierarchy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.0.1.tgz",
-      "integrity": "sha512-RlLTaofEoOrMK1JoXYIGhKTkJFI/6rFrYPgxy6QlZo2BcVc4HGTqEU0rPpzuMq5T/5XcMtAzv1XiLA3zRTfygw=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.1.tgz",
+      "integrity": "sha512-LtAIu54UctRmhGKllleflmHalttH3zkfSi4NlKrTAoFKjC+AFBJohsCAdgCBYQwH0F8hIOGY89X1pPqAchlMkA=="
     },
     "d3-interpolate": {
       "version": "3.0.1",
@@ -6519,9 +6519,9 @@
       }
     },
     "d3-time-format": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.0.0.tgz",
-      "integrity": "sha512-nzaCwlj+ZVBIlFuVOT1RmU+6xb/7D5IcnhHzHQcBgS/aTa5K9fWZNN5LCXA27LgF5WxoSNJqKBbLcGMtM6Ca6A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "requires": {
         "d3-time": "1 - 3"
       }
@@ -7104,9 +7104,9 @@
       }
     },
     "dompurify": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.3.tgz",
-      "integrity": "sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg=="
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz",
+      "integrity": "sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ=="
     },
     "domutils": {
       "version": "2.8.0",
@@ -10419,15 +10419,15 @@
       "dev": true
     },
     "mermaid": {
-      "version": "8.13.3",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.13.3.tgz",
-      "integrity": "sha512-w6KmDtSzkk856WUVqlBsyLZX0q4Jr35IlxiHTPTaWwMgWHFpI8rEJzcxWoyrpxeT/Rac/vvvSFOZymDTeA0iiA==",
+      "version": "8.13.8",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.13.8.tgz",
+      "integrity": "sha512-Z5v31rvo8P7BPTiGicdJl9BbzyUe9s5sXILK8sM1g7ijkagpfFjPtXZVsq5P1WlN8m/fUp2PPNXVF9SqeTM91w==",
       "requires": {
         "@braintree/sanitize-url": "^3.1.0",
         "d3": "^7.0.0",
         "dagre": "^0.8.5",
         "dagre-d3": "^0.6.4",
-        "dompurify": "2.3.3",
+        "dompurify": "2.3.4",
         "graphlib": "^2.1.8",
         "khroma": "^1.4.1",
         "moment-mini": "^2.24.0",
@@ -17131,9 +17131,9 @@
       }
     },
     "stylis": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
-      "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
     },
     "stylus": {
       "version": "0.55.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "dagre": "^0.8.4",
     "deepmerge": "^4.2.2",
     "mdast": "^3.0.0",
+    "mermaid": "^8.13.8",
     "msagl-js": "0.0.9",
     "ngx-logger": "^4.0.8",
     "path": "^0.12.7",

--- a/projects/swimlane/ngx-graph/src/lib/graph/layouts/colaForceDirected.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/layouts/colaForceDirected.ts
@@ -201,22 +201,20 @@ export class ColaForceDirectedLayout implements Layout {
         })
       );
 
-    this.outputGraph.clusters = internalGraph.groups.map(
-      (group, index): ClusterNode => {
-        const inputGroup = this.inputGraph.clusters[index];
-        return {
-          ...inputGroup,
-          dimension: {
-            width: group.bounds ? group.bounds.width() : 20,
-            height: group.bounds ? group.bounds.height() : 20
-          },
-          position: {
-            x: group.bounds ? group.bounds.x + group.bounds.width() / 2 : 0,
-            y: group.bounds ? group.bounds.y + group.bounds.height() / 2 : 0
-          }
-        };
-      }
-    );
+    this.outputGraph.clusters = internalGraph.groups.map((group, index): ClusterNode => {
+      const inputGroup = this.inputGraph.clusters[index];
+      return {
+        ...inputGroup,
+        dimension: {
+          width: group.bounds ? group.bounds.width() : 20,
+          height: group.bounds ? group.bounds.height() : 20
+        },
+        position: {
+          x: group.bounds ? group.bounds.x + group.bounds.width() / 2 : 0,
+          y: group.bounds ? group.bounds.y + group.bounds.height() / 2 : 0
+        }
+      };
+    });
     this.outputGraph.edgeLabels = this.outputGraph.edges;
     return this.outputGraph;
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ x] Other... Please describe:changing mermaid version from 8.13.3 to 8.13.8 to resolve vulnerability issue.

**What is the current behavior?** (You can also link to an open issue here)
Upgrade mermaid in ngx-graph

Impact
Malicious diagrams can contain javascript code that can be run at diagram readers machines.

Patches
The users should upgrade to version 8.13.8

Workarounds
You need to upgrade in order to avoid this issue.


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
