### PR TITLE
rxjs 7 support

### DIFF
--- a/projects/swimlane/ngx-graph/package.json
+++ b/projects/swimlane/ngx-graph/package.json
@@ -33,7 +33,7 @@
     "@angular/common": "10.x || 11.x || 12.x || 13.x",
     "@angular/core": "10.x || 11.x || 12.x || 13.x",
     "@angular/cdk": "10.x || 11.x || 12.x || 13.x",
-    "rxjs": "6.x"
+    "rxjs": "6.x || 7.x"
   },
   "dependencies": {
     "d3-dispatch": "^1.0.3",


### PR DESCRIPTION
Update dependencies to support rxjs 7 projects

**What kind of change does this PR introduce?**
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

Library is not compatible with rxjs 7 + without using --force or --legacy-peer-deps
Related issue: https://github.com/swimlane/ngx-graph/issues/432

**What is the new behavior?**

Library is able to be used with rxjs 7 projects without using --force or --legacy-peer-deps

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
