### PR TITLE
only reset position if no position is provided

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -361,10 +361,13 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
       } else {
         n.meta.forceDimensions = n.meta.forceDimensions === undefined ? true : n.meta.forceDimensions;
       }
-      n.position = {
-        x: 0,
-        y: 0
-      };
+      if (!n.position) {
+        n.position = {
+          x: 0,
+          y: 0
+        };
+      }
+
       n.data = n.data ? n.data : {};
       return n;
     };


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently the position get's always reset
https://github.com/swimlane/ngx-graph/issues/322

**What is the new behavior?**
This allows to pass a position into the lib. Then it is depending on the Layout used.
Most of the layouts use `dagre.layout(this.dagreGraph);`, which set automatically a position, but if you override this call in the layout (with a custom layout), it will use the provided position


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No -> it think so it's depending on the layouts


**Other information**:
