### PR TITLE
Change panToNode$ to only pan in the direction configured

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -1143,8 +1143,17 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     if (!node) {
       return;
     }
-
-    this.panTo(node.position.x, node.position.y);
+    switch (this.panningAxis) {
+      case PanningAxis.Both:
+        this.panTo(node.position.x, node.position.y);
+        break;
+      case PanningAxis.Horizontal:
+        this.panTo(node.position.x, null);
+        break;
+      case PanningAxis.Vertical:
+        this.panTo(null, node.position.y);
+        break;
+    }
   }
 
   private panWithConstraints(key: string, event: MouseEvent) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

I have a wide graph with only horizontal panning.

The problem is when using `panToNode$` to pan to a node, the graph pans vertically as well as horizontally, even though vertical panning is disabled, causing a portion of the graph to go off-screen with no way to bring it back.

My graph looks like this (four rows):
![2022-10-13-113609_1092x484_scrot](https://user-images.githubusercontent.com/4387517/195561752-890ea219-aa2b-4387-8db7-b9e09547c7a6.png)


But after using `panToNode$` (panning to the orange node, see screenshot below) the top row has gone outside of the viewable area, because the graph has panned vertically even though that's been disabled (only three out of four rows visible now):
![2022-10-13-113639_1166x491_scrot](https://user-images.githubusercontent.com/4387517/195561747-2e1c5706-d055-47e4-a0fb-245f83e604f8.png)

To reproduce the issue: 
1. Set `PanningAxis` to something other than `Both`, for example, `Horizontal`
2. Use `panToNode$` to pan to a specific node
3. Observe that the node is now centred, and that the graph has panned vertically as well, even though vertical panning is not allowed


**What is the new behavior?**

Check which way may be panned, and then only pan that way. 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

