### PR TITLE
fix panTo so it works with the panOffsetX/panOffsetY setters

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -804,10 +804,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    * Pan to a fixed x/y
    *
    */
-  panTo(x: number, y: number): void {
-    if (x === null || x === undefined || isNaN(x) || y === null || y === undefined || isNaN(y)) {
-      return;
-    }
+  panTo(x: number | null, y: number | null): void {
+    x = isFinite(x) ? x : this.transformationMatrix.e;
+    y = isFinite(y) ? y : this.transformationMatrix.f;
 
     const panX = -this.panOffsetX - x * this.zoomLevel + this.dims.width / 2;
     const panY = -this.panOffsetY - y * this.zoomLevel + this.dims.height / 2;

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -805,8 +805,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    *
    */
   panTo(x: number | null, y: number | null): void {
-    x = isFinite(x) ? x : this.transformationMatrix.e;
-    y = isFinite(y) ? y : this.transformationMatrix.f;
+    x = isFinite(x ?? undefined) ? x : this.transformationMatrix.e;
+    y = isFinite(y ?? undefined) ? y : this.transformationMatrix.f;
 
     const panX = -this.panOffsetX - x * this.zoomLevel + this.dims.width / 2;
     const panY = -this.panOffsetY - y * this.zoomLevel + this.dims.height / 2;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

This PR is meant to work together with #470.

Look at the setters for `panOffsetX` and `panOffsetY` defined here:

https://github.com/swimlane/ngx-graph/blob/11a1a2d5c485418e77e3398349010393283861eb/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts#L190-L193

They are passing `null` to `panTo(x, y)` for the coordinate not being set. But `panTo` does nothing upon receving `null` for any argument:

https://github.com/swimlane/ngx-graph/blob/11a1a2d5c485418e77e3398349010393283861eb/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts#L807-L810

This bug was introduced with this commit: https://github.com/swimlane/ngx-graph/commit/09cb4db4a3fd2fcfffc5399f56a0212c5a8ffe8f


**What is the new behavior?**

Fix `panTo(x,y)` so that it works with passing `null` for either of its arguments.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
