### PR TITLE
Modified the Dependency Injectection for lazy-loaded modules

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.module.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { GraphComponent } from './graph.component';
 import { MouseWheelDirective } from './mouse-wheel.directive';
-import { LayoutService } from './layouts/layout.service';
 import { CommonModule } from '@angular/common';
 import { VisibilityObserver } from '../utils/visibility-observer';
 export { GraphComponent };
@@ -10,6 +9,6 @@ export { GraphComponent };
   imports: [CommonModule],
   declarations: [GraphComponent, MouseWheelDirective, VisibilityObserver],
   exports: [GraphComponent, MouseWheelDirective],
-  providers: [LayoutService]
+  providers: []
 })
 export class GraphModule {}

--- a/projects/swimlane/ngx-graph/src/lib/graph/layouts/layout.service.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/layouts/layout.service.ts
@@ -14,7 +14,9 @@ const layouts = {
   colaForceDirected: ColaForceDirectedLayout
 };
 
-@Injectable()
+@Injectable({
+  providedIn: 'any'
+})
 export class LayoutService {
   getLayout(name: string): Layout {
     if (layouts[name]) {


### PR DESCRIPTION


**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently, getting the following error while trying to lazily load NgxModule:

ERROR NullInjectorError: R3InjectorError(AppModule)[LayoutService -> LayoutService -> LayoutService]:
NullInjectorError: No provider for LayoutService!
In order to try to solve the problem, i tried instanciating the service by myself, but
Module not found: Error: Package path ./lib/graph/layouts/layout.service is not exported from package


**What is the new behavior?**
Lazily loads without any exception.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
