### PR TITLE
upgrade d3-shape version

### DIFF
--- a/projects/swimlane/ngx-graph/package.json
+++ b/projects/swimlane/ngx-graph/package.json
@@ -41,7 +41,7 @@
     "d3-force": "^1.1.0",
     "d3-scale": "^3.2.3",
     "d3-selection": "^1.2.0",
-    "d3-shape": "^1.2.0",
+    "d3-shape": "^3.2.0",
     "d3-timer": "^1.0.7",
     "d3-transition": "^3.0.1",
     "dagre": "^0.8.4",


### PR DESCRIPTION
using a more stable version of d3-shape.
this should fix the error shown in the console when you drag the graph outside its div:  ERROR TypeError: Cannot read properties of undefined (reading 'length')
    at line (line.js:16:1)
    at GraphComponent.generateLine (swimlane-ngx-graph.mjs:1783:16)

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
console shows errors accessing undefined object


**What is the new behavior?**
no error is shown


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
