### PR TITLE
feat: defer display until layout provides position

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.html
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.html
@@ -46,7 +46,7 @@
           (click)="onClick(node)"
         >
           <ng-container
-            *ngIf="clusterTemplate"
+            *ngIf="clusterTemplate && !node.hidden"
             [ngTemplateOutlet]="clusterTemplate"
             [ngTemplateOutletContext]="{ $implicit: node }"
           ></ng-container>
@@ -75,7 +75,7 @@
           (mousedown)="onNodeMouseDown($event, node)"
         >
           <ng-container
-            *ngIf="nodeTemplate"
+            *ngIf="nodeTemplate && !node.hidden"
             [ngTemplateOutlet]="nodeTemplate"
             [ngTemplateOutletContext]="{ $implicit: node }"
           ></ng-container>
@@ -115,7 +115,7 @@
           (mousedown)="onNodeMouseDown($event, node)"
         >
           <ng-container
-            *ngIf="nodeTemplate"
+            *ngIf="nodeTemplate && !node.hidden"
             [ngTemplateOutlet]="nodeTemplate"
             [ngTemplateOutletContext]="{ $implicit: node }"
           ></ng-container>

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -104,6 +104,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   @Input() scheme: any = 'cool';
   @Input() customColors: any;
   @Input() animations: boolean = true;
+  @Input() deferDisplayUntilPosition: boolean = false;
   @Output() select = new EventEmitter();
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
@@ -368,6 +369,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
           x: 0,
           y: 0
         };
+        if (this.deferDisplayUntilPosition) {
+          n.hidden = true;
+        }
       }
 
       n.data = n.data ? n.data : {};
@@ -435,6 +439,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
         n.data = {};
       }
       n.data.color = this.colors.getColor(this.groupResultsBy(n));
+      if (this.deferDisplayUntilPosition) {
+        n.hidden = false;
+      }
       oldNodes.add(n.id);
     });
 

--- a/projects/swimlane/ngx-graph/src/lib/models/node.model.ts
+++ b/projects/swimlane/ngx-graph/src/lib/models/node.model.ts
@@ -18,6 +18,7 @@ export interface Node {
   meta?: any;
   layoutOptions?: any;
   parentId?: string;
+  hidden?: boolean;
 }
 
 export interface ClusterNode extends Node {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [X ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

ngx-graph assigns position prior to layout dictating position. 

**What is the new behavior?**

This feature defers nodes from displaying until after position has been assigned by a layout. The feature is opt-in by providing an `@Input` named `deferDisplayUntilPosition` and setting it to `true`.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
