### PR TITLE
fix: show clusters and compound nodes when deferring

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -456,6 +456,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
         n.data = {};
       }
       n.data.color = this.colors.getColor(this.groupResultsBy(n));
+      if (this.deferDisplayUntilPosition) {
+        n.hidden = false;
+      }
       oldClusters.add(n.id);
     });
 
@@ -467,6 +470,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
         n.data = {};
       }
       n.data.color = this.colors.getColor(this.groupResultsBy(n));
+      if (this.deferDisplayUntilPosition) {
+        n.hidden = false;
+      }
       oldCompoundNodes.add(n.id);
     });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When using the new `deferDisplayUntilPosition` Input introduced in 8.2.0, cluster nodes and compound nodes may not appear properly. 

**What is the new behavior?**

This fixes the issue by setting `hidden` to `false` on clusters and compound nodes when the Input is truthy.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
