### PR TITLE
fix: correct translation on parent components

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -430,13 +430,18 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   }
 
   tick() {
+    const translationVector = (node: Node): [number, number] => {
+      const xTranslate = node.position.x - (this.centerNodesOnPositionChange ? node.dimension.width / 2 : 0) || 0;
+      const yTranslate = node.position.y - (this.centerNodesOnPositionChange ? node.dimension.height / 2 : 0) || 0;
+      return [xTranslate, yTranslate];
+    };
+
     // Transposes view options to the node
     const oldNodes: Set<string> = new Set();
 
     this.graph.nodes.map(n => {
-      n.transform = `translate(${n.position.x - (this.centerNodesOnPositionChange ? n.dimension.width / 2 : 0) || 0}, ${
-        n.position.y - (this.centerNodesOnPositionChange ? n.dimension.height / 2 : 0) || 0
-      })`;
+      const [xTranslate, yTranslate] = translationVector(n);
+      n.transform = `translate(${xTranslate}, ${yTranslate})`;
       if (!n.data) {
         n.data = {};
       }
@@ -451,9 +456,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     const oldCompoundNodes: Set<string> = new Set();
 
     (this.graph.clusters || []).map(n => {
-      n.transform = `translate(${
-        n.position.x - (this.centerNodesOnPositionChange ? n.dimension.width / 2 : 0) / 2 || 0
-      }, ${n.position.y - (this.centerNodesOnPositionChange ? n.dimension.height / 2 : 0) || 0})`;
+      const [xTranslate, yTranslate] = translationVector(n);
+      n.transform = `translate(${xTranslate}, ${yTranslate})`;
       if (!n.data) {
         n.data = {};
       }
@@ -465,9 +469,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     });
 
     (this.graph.compoundNodes || []).map(n => {
-      n.transform = `translate(${
-        n.position.x - (this.centerNodesOnPositionChange ? n.dimension.width / 2 : 0) / 2 || 0
-      }, ${n.position.y - (this.centerNodesOnPositionChange ? n.dimension.height / 2 : 0) || 0})`;
+      const [xTranslate, yTranslate] = translationVector(n);
+      n.transform = `translate(${xTranslate}, ${yTranslate})`;
       if (!n.data) {
         n.data = {};
       }


### PR DESCRIPTION
The translation applied to cluster and compound nodes was calculated incorrectly. This commit correctly centers parent components over their children.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Parent nodes (cluster nodes and compound nodes) are too far to the right relative to their children, when `centerNodesOnPositionChange==true`.

![Cluster nodes are not centered on their children](https://github.com/swimlane/ngx-graph/assets/58090753/18fce342-47fa-4272-9f15-7e5d704066ef)


**What is the new behavior?**
Parent nodes are centered on their children.
![Screenshot 2023-11-08 220027](https://github.com/swimlane/ngx-graph/assets/58090753/e898da33-1e26-4e1a-b654-d801bf957ff4)


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
