### PR TITLE
feat: add ng-content at the end of the svg to allow users to add custom svg elements over the nodes.

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.html
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.html
@@ -128,6 +128,8 @@
           />
         </svg:g>
       </svg:g>
+
+      <ng-content select=".end-content"></ng-content>
     </svg:g>
 
     <svg:clipPath [attr.id]="minimapClipPathId">


### PR DESCRIPTION
As SVG Renders in Order as provided in the DOM with the current approach we can only add elements in the background but this ng-content allows with the class "end-content" to brings them into the foreground

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Custom SVG Elements only in Background


**What is the new behavior?**
Custom SVG Elements in Background and Foreground


**Does this PR introduce a breaking change?** (check one with "x")
- [X] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
If someone used already the css class "end-content" the svg elements would go into foreground, but i guess this is unlikely

**Other information**:
