### PR TITLE
fix: disable mousewheel directive when zoom is disabled

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.html
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.html
@@ -5,7 +5,7 @@
   [@.disabled]="!animations"
   (mouseWheelUp)="onZoom($event, 'in')"
   (mouseWheelDown)="onZoom($event, 'out')"
-  mouseWheel
+  [mouseWheel]="enableZoom"
 >
   <svg:svg class="ngx-charts" [attr.width]="width" [attr.height]="height">
     <svg:g

--- a/projects/swimlane/ngx-graph/src/lib/graph/mouse-wheel.directive.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/mouse-wheel.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Output, HostListener, EventEmitter } from '@angular/core';
+import { Directive, Input, Output, HostListener, EventEmitter } from '@angular/core';
 
 /**
  * Mousewheel directive
@@ -9,6 +9,8 @@ import { Directive, Output, HostListener, EventEmitter } from '@angular/core';
 // tslint:disable-next-line: directive-selector
 @Directive({ selector: '[mouseWheel]' })
 export class MouseWheelDirective {
+  @Input() mouseWheel: boolean;
+
   @Output()
   mouseWheelUp = new EventEmitter();
   @Output()
@@ -35,6 +37,10 @@ export class MouseWheelDirective {
   }
 
   mouseWheelFunc(event: any): void {
+    if (!this.mouseWheel) {
+      return;
+    }
+
     if (window.event) {
       event = window.event;
     }


### PR DESCRIPTION
This allows to normally scroll through page when zoom is disabled.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When zoom is disabled you can't use mouse wheel to scroll to the bottom of page if mouse is over the ngx-graph component.

**What is the new behavior?**

If zoom is disabled you can normally use your mouse wheel to scroll.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
