### PR TITLE
Fix: Rendering Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,19 +272,19 @@ Run `npm run test` to execute the linter
 
 ## Release
 
-Checkout master (`git checkout master`)
-Pull master (`git pull`)
-Refresh node modules (`npm ci`)
-Run tests (`npm test`)
-Examine log to determine next version (X.Y.Z)
-Run `git checkout -b release/X.Y.Z`
-Update version in `projects/swimlane/ngx-graph/package.json`.
-Update changelog in `projects/swimlane/ngx-graph/CHANGELOG.md`
-Run `git commit -am "(release): X.Y.Z"`
-Run `git tag X.Y.Z`
-Run `git push origin HEAD --tags`
-Run `npm run publish:lib`
-Submit PR
+- Checkout master (`git checkout master`)
+- Pull master (`git pull`)
+- Refresh node modules (`npm ci`)
+- Run tests (`npm test`)
+- Examine log to determine next version (X.Y.Z)
+- Run `git checkout -b release/X.Y.Z`
+- Update version in `projects/swimlane/ngx-graph/package.json`.
+- Update changelog in `projects/swimlane/ngx-graph/CHANGELOG.md`
+- Run `git commit -am "(release): X.Y.Z"`
+- Run `git tag X.Y.Z`
+- Run `git push origin HEAD --tags`
+- Run `npm run publish:lib`
+- Submit PR
 
 ## Credits
 

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -25,8 +25,8 @@ import { select } from 'd3-selection';
 import * as shape from 'd3-shape';
 import * as ease from 'd3-ease';
 import 'd3-transition';
-import { Observable, Subscription, of, fromEvent as observableFromEvent } from 'rxjs';
-import { first, debounceTime } from 'rxjs/operators';
+import { Observable, Subscription, of, fromEvent as observableFromEvent, Subject } from 'rxjs';
+import { first, debounceTime, takeUntil } from 'rxjs/operators';
 import { identity, scale, smoothMatrix, toSVG, transform, translate } from 'transformation-matrix';
 import { Layout } from '../models/layout.model';
 import { LayoutService } from './layouts/layout.service';
@@ -51,6 +51,11 @@ export interface Matrix {
   d: number;
   e: number;
   f: number;
+}
+
+export interface ZoomOptions {
+  autoCenter?: boolean;
+  force?: boolean;
 }
 
 @Component({
@@ -91,7 +96,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   @Input() autoCenter = false;
   @Input() update$: Observable<any>;
   @Input() center$: Observable<any>;
-  @Input() zoomToFit$: Observable<any>;
+  @Input() zoomToFit$: Observable<ZoomOptions>;
   @Input() panToNode$: Observable<any>;
   @Input() layout: string | Layout;
   @Input() layoutSettings: any;
@@ -106,12 +111,14 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   @Input() animations: boolean = true;
   @Input() deferDisplayUntilPosition: boolean = false;
   @Input() centerNodesOnPositionChange = true;
+  @Input() enablePreUpdateTransform = true;
 
   @Output() select = new EventEmitter();
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();
   @Output() zoomChange: EventEmitter<number> = new EventEmitter();
   @Output() clickHandler: EventEmitter<MouseEvent> = new EventEmitter();
+  @Output() stateChange: EventEmitter<{ state: 'init' | 'subscribe' | 'transform' }> = new EventEmitter();
 
   @ContentChild('linkTemplate') linkTemplate: TemplateRef<any>;
   @ContentChild('nodeTemplate') nodeTemplate: TemplateRef<any>;
@@ -127,7 +134,6 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   private isMouseMoveCalled: boolean = false;
 
   graphSubscription: Subscription = new Subscription();
-  subscriptions: Subscription[] = [];
   colors: ColorHelper;
   dims: ViewDimensions;
   seriesDomain: any;
@@ -155,6 +161,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   height: number;
   resizeSubscription: any;
   visibilityObserver: VisibilityObserver;
+  private destroy$ = new Subject<void>();
 
   constructor(
     private el: ElementRef,
@@ -219,38 +226,31 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    */
   ngOnInit(): void {
     if (this.update$) {
-      this.subscriptions.push(
-        this.update$.subscribe(() => {
-          this.update();
-        })
-      );
+      this.update$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+        this.update();
+      });
     }
 
     if (this.center$) {
-      this.subscriptions.push(
-        this.center$.subscribe(() => {
-          this.center();
-        })
-      );
+      this.center$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+        this.center();
+      });
     }
 
     if (this.zoomToFit$) {
-      this.subscriptions.push(
-        this.zoomToFit$.subscribe(() => {
-          this.zoomToFit();
-        })
-      );
+      this.zoomToFit$.pipe(takeUntil(this.destroy$)).subscribe(options => {
+        this.zoomToFit(options ? options : {});
+      });
     }
 
     if (this.panToNode$) {
-      this.subscriptions.push(
-        this.panToNode$.subscribe((nodeId: string) => {
-          this.panToNodeId(nodeId);
-        })
-      );
+      this.panToNode$.pipe(takeUntil(this.destroy$)).subscribe((nodeId: string) => {
+        this.panToNodeId(nodeId);
+      });
     }
 
     this.minimapClipPathId = `minimapClip${id()}`;
+    this.stateChange.emit({ state: 'subscribe' });
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -293,11 +293,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
       this.visibilityObserver.visible.unsubscribe();
       this.visibilityObserver.destroy();
     }
-
-    for (const sub of this.subscriptions) {
-      sub.unsubscribe();
-    }
-    this.subscriptions = null;
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   /**
@@ -338,6 +335,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
 
       this.createGraph();
       this.updateTransform();
+      if (!this.initialized) {
+        this.stateChange.emit({ state: 'init' });
+      }
       this.initialized = true;
     });
   }
@@ -870,7 +870,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     this.transformationMatrix.a = isNaN(level) ? this.transformationMatrix.a : Number(level);
     this.transformationMatrix.d = isNaN(level) ? this.transformationMatrix.d : Number(level);
     this.zoomChange.emit(this.zoomLevel);
-    this.updateTransform();
+    if (this.enablePreUpdateTransform) {
+      this.updateTransform();
+    }
     this.update();
   }
 
@@ -935,6 +937,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    */
   updateTransform(): void {
     this.transform = toSVG(smoothMatrix(this.transformationMatrix, 100));
+    this.stateChange.emit({ state: 'transform' });
   }
 
   /**
@@ -1144,9 +1147,10 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   }
 
   /**
-   * Zooms to fit the entier graph
+   * Zooms to fit the entire graph
    */
-  zoomToFit(): void {
+  zoomToFit(zoomOptions?: ZoomOptions): void {
+    this.updateGraphDims();
     const heightZoom = this.dims.height / this.graphDims.height;
     const widthZoom = this.dims.width / this.graphDims.width;
     let zoomLevel = Math.min(heightZoom, widthZoom, 1);
@@ -1159,9 +1163,14 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
       zoomLevel = this.maxZoomLevel;
     }
 
-    if (zoomLevel !== this.zoomLevel) {
+    if (zoomOptions?.force === true || zoomLevel !== this.zoomLevel) {
       this.zoomLevel = zoomLevel;
-      this.updateTransform();
+      if (!zoomOptions?.autoCenter !== true) {
+        this.updateTransform();
+      }
+      if (zoomOptions?.autoCenter === true) {
+        this.center();
+      }
       this.zoomChange.emit(this.zoomLevel);
     }
   }
@@ -1307,6 +1316,36 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     }
 
     return null;
+  }
+
+  /**
+   * Checks if the graph has dimensions
+   */
+  public hasGraphDims(): boolean {
+    return this.graphDims.width > 0 && this.graphDims.height > 0;
+  }
+
+  /**
+   * Checks if all nodes have dimension
+   */
+  public hasNodeDims(): boolean {
+    return this.graph.nodes?.filter(node => node.dimension.width === 0 && node.dimension.height === 0).length === 0;
+  }
+
+  /**
+   * Checks if all compound nodes have dimension
+   */
+  public hasCompoundNodeDims(): boolean {
+    return (
+      this.graph.compoundNodes?.filter(node => node.dimension.width === 0 && node.dimension.height === 0).length === 0
+    );
+  }
+
+  /**
+   * Checks if the graph and all nodes have dimension.
+   */
+  public hasDims(): boolean {
+    return this.hasGraphDims() && this.hasNodeDims() && this.hasCompoundNodeDims();
   }
 
   protected unbindEvents(): void {

--- a/src/docs/main.md
+++ b/src/docs/main.md
@@ -87,13 +87,15 @@ ngx-graph is a graph visualization library for Angular
 | miniMapMaxWidth                                           | number              | 100                              | the maximum width of the minimap (in pixels)                                                                                                        |
 | miniMapMaxHeight                                          | number              |                                  | the maximum height of the minimap (in pixels)                                                                                                       |
 | miniMapPosition                                           | MiniMapPosition     | MiniMapPosition.UpperRight       | the position of the minimap                                                                                                                         |
+| enablePreUpdateTransform                                  | boolean             | true                             | When set to false, disables an extra transform cycle when the graph updates                                                                         |
 
 _Deprecated inputs will be removed in the next major version of the package._
 
 ## Outputs
 
-| Event      | Description                                 |
-| ---------- | ------------------------------------------- |
-| activate   | element activation event (mouse enter)      |
-| deactivate | element deactivation event (mouse leave)    |
-| zoomChange | zoom change event, emits the new zoom level |
+| Event       | Description                                                                          |
+| ----------- | ------------------------------------------------------------------------------------ |
+| activate    | element activation event (mouse enter)                                               |
+| deactivate  | element deactivation event (mouse leave)                                             |
+| zoomChange  | zoom change event, emits the new zoom level                                          |
+| stateChange | state change event, emits lifecycle events like `init`, `transform`, and `subscribe` |


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

1. User has no way to accurately detect state of the graph on load. Suppose the use case where the user wants to zoom to fit and center on load. This depends on the graph having accurate dimensions, all the nodes having accurate dimensions, but there is no way to tell. This PR adds several outward facing methods to detect if elements have dimension. In addition, a new `@Output` named `stateChanges` allows users to listen for changes to the graph. Combined with the being able to check dimensions, a user should now be able to call `zoomToFit` accurately.
2. `zoomToFit` results in two updates to the transform, introducing a flicker when combined with calls to `center()`. A new optional `ZoomOptions` can be used to call `next()` on `zoomToFit$` with the option `autoCenter`, reducing the need to call a second time and introducing a flicker. `autoCenter` also defers updating the transform on `panTo`.
3. Sometimes `zoomToFit$` fails because of an internal check of the zoom value and nothing happens except the graph flickers in place. A new `ZoomOption` named `force` allows users to bypass the check and zoom to fit anyways.
4. `subscriptions` is deprecated in favor of listening for a `destroy$ Subject`. This matches other `Component` style.
5. New `enablePreUpdateTransform @Input` allows users to disable an update to the transform that happens before another update, reducing the chance of a flicker.




**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
