### PR TITLE
chore: allow future angular versions

### DIFF
--- a/projects/swimlane/ngx-graph/package.json
+++ b/projects/swimlane/ngx-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-graph",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "Graph visualization for angular",
   "repository": {
     "type": "git",
@@ -30,11 +30,11 @@
   },
   "homepage": "https://github.com/swimlane/ngx-graph#readme",
   "peerDependencies": {
-    "@angular/animations": "10.x || 11.x || 12.x || 13.x || 14.x || 15.x || 16.x",
-    "@angular/common": "10.x || 11.x || 12.x || 13.x || 14.x || 15.x || 16.x",
-    "@angular/core": "10.x || 11.x || 12.x || 13.x || 14.x || 15.x || 16.x",
-    "@angular/cdk": "10.x || 11.x || 12.x || 13.x || 14.x || 15.x || 16.x",
-    "rxjs": "6.x || 7.x"
+    "@angular/animations": ">=10.0.0",
+    "@angular/common": ">=10.0.0",
+    "@angular/core": ">=10.0.0",
+    "@angular/cdk": ">=10.0.0",
+    "rxjs": ">=6.0.0"
   },
   "dependencies": {
     "d3-dispatch": "^1.0.3",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Allow package installation for future angular versions.

**What is the current behavior?** (You can also link to an open issue here)
The library `@swimlane/ngx-graph` specifies peer dependencies that only support Angular versions up to 16.x. This creates issues when trying to use the library with newer versions of Angular.


**What is the new behavior?**
This PR updates the `package.json` to allow for any Angular versions greater than or equal to 10.0.0. This change removes the need to publish a new version of the library every time a new major version of Angular is released.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<img width="1722" alt="Screenshot 2024-06-23 at 10 09 51 PM" src="https://github.com/swimlane/ngx-graph/assets/98421392/84d55917-9d56-4ea7-8e2f-4fa994bf3a5c">
