### PR TITLE
:bangbang: Hotfix: Allow graph creation with empty nodes and links :bangbang:

### DIFF
--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -271,7 +271,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     if (layoutSettings) {
       this.setLayoutSettings(this.layoutSettings);
     }
-    if (this.layout && this.nodes.length && this.links.length) {
+    if (this.layout && this.nodes && this.links) {
       this.update();
     }
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
At the moment, graphs with 0 nodes or 0 links crash the component with `undefined` errors, because the graph is not created and `this.graph.nodes` is still invoked


**What is the new behavior?**
Graphs with 0 nodes or 0 links can be used without `undefined` errors. Closes #559 


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

**Other information**:
Please merge this PR asap and create a bugfix release 9.0.2 as we currently cannot upgrade to 9.x