### PR TITLE
Add Checks For nodes and edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## HEAD (unreleased)
 
-## 12.0.0-alpha.4
-
 - Fix: possible console error when nodes or edges are not available during ngOnChanges.
 
 ## 12.0.0-alpha.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD (unreleased)
 
+## 12.0.0-alpha.4
+
+- Fix: possible console error when nodes or edges are not available during ngOnChanges.
+
 ## 12.0.0-alpha.3
 
 - Fix: Suppress layout animation on zoom.

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
@@ -1120,6 +1120,17 @@ describe('GraphComponent viewport interactions', () => {
     expect(graph.graph.compoundNodes).toEqual([]);
     expect(graph.graph.edges).toEqual([]);
   }));
+
+  it('ngOnChanges tolerates null nodes/links inputs without calling update', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestViewportInteractionsHostComponent);
+    const graph = bootstrap(fixture);
+    spyOn(graph, 'nodes').and.returnValue(null as unknown as Node[]);
+    spyOn(graph, 'links').and.returnValue(null as unknown as Edge[]);
+    spyOn(graph, 'layout').and.returnValue('dagre');
+    const updateSpy = spyOn(graph, 'update').and.stub();
+    expect(() => graph.ngOnChanges({})).not.toThrow();
+    expect(updateSpy).not.toHaveBeenCalled();
+  }));
 });
 
 describe('GraphComponent panning axis constraints', () => {

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -495,7 +495,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     if (layoutSettings) {
       this.setLayoutSettings(this.layoutSettings());
     }
-    if (layout && this.nodes().length && this.links().length) {
+    const nodes = this.nodes() ?? [];
+    const links = this.links() ?? [];
+    if (layout && nodes.length && links.length) {
       this.update();
     }
   }


### PR DESCRIPTION


**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Console error sometimes when graph renders.

**What is the new behavior?**

- Fix: possible console error when nodes or edges are not available during ngOnChanges.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive null-coalescing in ngOnChanges with a regression test; no API or layout behavior change beyond skipping update when inputs are empty.
> 
> **Overview**
> **`GraphComponent.ngOnChanges`** no longer calls `.length` on raw `nodes()` / `links()` signal values. It coalesces **`null`/`undefined` to `[]`** before deciding whether to run **`update()`**, matching **`createGraph`** and **`buildInputTopology`** and avoiding a console error when inputs are missing during change detection.
> 
> A **unit test** asserts **`ngOnChanges`** does not throw and does not call **`update()`** when **`nodes`** and **`links`** are **`null`**. **CHANGELOG** documents the fix under HEAD.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eaf196a18ec5423add626cc934d391a391a603d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->