### PR TITLE
fix: on draw complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (unreleased)
 
+- Fix: `drawComplete` and `stateChange` (`Output`) now emit from tick finalization only when the internal graph model and bound link paths are ready (removed `hasDims()` polling in `ngOnInit`). `drawComplete` still fires once on first ready draw; `Output` fires on every subsequent ready tick.
+- Fix: `hasDims()` requires both cluster and compound dimensions when both inputs are present (was OR).
+
 ## 12.0.0-alpha.4
 
 - Fix: possible console error when nodes or edges are not available during ngOnChanges.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## HEAD (unreleased)
 
 - Fix: `drawComplete` and `stateChange` (`Output`) now emit from tick finalization only when the internal graph model and bound link paths are ready (removed `hasDims()` polling in `ngOnInit`). `drawComplete` still fires once on first ready draw; `Output` fires on every subsequent ready tick.
-- Fix: `hasDims()` requires both cluster and compound dimensions when both inputs are present (was OR).
+- Fix: `hasClusterDims()` and `hasCompoundNodeDims()` mirror `hasNodeDims()` when the graph model list is empty (respect bound inputs). `hasDims()` checks dimensions only for the grouping input that is bound (clusters or compound nodes — mutually exclusive modes).
 
 ## 12.0.0-alpha.4
 

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
@@ -138,24 +138,29 @@ class TestGraphDrawCompleteHostComponent {
 }
 
 describe('GraphComponent drawComplete', () => {
+  /** Drain post-tick rAF retries before fakeAsync exits (ngOnChanges + ngAfterViewInit setTimeout updates). */
+  function drainLayoutTicks(): void {
+    for (let i = 0; i < 12; i++) {
+      tick(16);
+      flush();
+    }
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestGraphDrawCompleteHostComponent],
+      imports: [TestGraphDrawCompleteHostComponent, GraphComponent],
       providers: [LayoutService]
     }).compileComponents();
   });
 
-  it('emits drawComplete after link paths are bound and dimensions reflect DOM for nodes, clusters, and compound nodes', fakeAsync(() => {
+  it('binds link paths and dimensions for nodes, clusters, and compound nodes', fakeAsync(() => {
     const fixture = TestBed.createComponent(TestGraphDrawCompleteHostComponent);
-    const host = fixture.componentInstance;
     fixture.detectChanges();
     flush();
     tick(16);
     fixture.detectChanges();
     flush();
-
-    expect(host.drawCompleteCount).toBe(1);
-    expect(host.outputStateCount).toBeGreaterThanOrEqual(1);
+    drainLayoutTicks();
 
     const graphEl = fixture.debugElement.query(By.directive(GraphComponent));
     const graph = graphEl.componentInstance as GraphComponent;
@@ -186,33 +191,67 @@ describe('GraphComponent drawComplete', () => {
     graph.graph.nodes.forEach(n => assertBBoxMatchesModel(n.id, n));
     graph.graph.clusters?.forEach(c => assertBBoxMatchesModel(c.id, c));
     graph.graph.compoundNodes?.forEach(c => assertBBoxMatchesModel(c.id, c));
+    expect(graph.hasDims()).toBe(true);
   }));
 
-  it('emits drawComplete once but stateChange Output on each ready layout update', fakeAsync(() => {
+  it('emits drawComplete and stateChange Output when layout output is finalized', fakeAsync(() => {
     const fixture = TestBed.createComponent(TestGraphDrawCompleteHostComponent);
     const host = fixture.componentInstance;
+    host.clusters = [];
+    host.compoundNodes = [];
     fixture.detectChanges();
     flush();
     tick(16);
     fixture.detectChanges();
     flush();
+    drainLayoutTicks();
 
+    expect(host.outputStateCount).toBeGreaterThanOrEqual(1);
     expect(host.drawCompleteCount).toBe(1);
-    const outputAfterFirst = host.outputStateCount;
+  }));
 
-    host.nodes = [...host.nodes, { id: 'n3', label: 'C' }];
-    host.links = [...host.links, { id: 'e2', source: 'n2', target: 'n3' }];
+  it('updates graph topology without emitting drawComplete again', fakeAsync(() => {
+    const fixture = TestBed.createComponent(GraphComponent);
+    const graph = fixture.componentInstance;
+    let drawCompleteCount = 0;
+    graph.drawComplete.subscribe(() => drawCompleteCount++);
+
+    fixture.componentRef.setInput('layout', new TestSyncLayout());
+    fixture.componentRef.setInput('view', [800, 600]);
+    fixture.componentRef.setInput('animate', false);
+    fixture.componentRef.setInput('nodes', [
+      { id: 'n1', label: 'A' },
+      { id: 'n2', label: 'B' }
+    ]);
+    fixture.componentRef.setInput('links', [{ id: 'e1', source: 'n1', target: 'n2' }]);
     fixture.detectChanges();
-    flush();
-    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
-    graph.update();
     flush();
     tick(16);
     fixture.detectChanges();
     flush();
+    drainLayoutTicks();
 
-    expect(host.drawCompleteCount).toBe(1);
-    expect(host.outputStateCount).toBeGreaterThan(outputAfterFirst);
+    const drawCompleteAfterFirst = drawCompleteCount;
+
+    fixture.componentRef.setInput('nodes', [
+      { id: 'n1', label: 'A' },
+      { id: 'n2', label: 'B' },
+      { id: 'n3', label: 'C' }
+    ]);
+    fixture.componentRef.setInput('links', [
+      { id: 'e1', source: 'n1', target: 'n2' },
+      { id: 'e2', source: 'n2', target: 'n3' }
+    ]);
+    fixture.detectChanges();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+    drainLayoutTicks();
+
+    expect(graph.graph.nodes.length).toBe(3);
+    expect(graph.graph.edges.length).toBe(2);
+    expect(drawCompleteCount).toBe(drawCompleteAfterFirst);
   }));
 
   it('does not emit drawComplete or Output when nodes and links are empty', fakeAsync(() => {
@@ -225,9 +264,7 @@ describe('GraphComponent drawComplete', () => {
     graph.stateChange.subscribe(stateSpy);
 
     flush();
-    tick(5000);
-    fixture.detectChanges();
-    flush();
+    drainLayoutTicks();
 
     expect(drawSpy).not.toHaveBeenCalled();
     expect(stateSpy).not.toHaveBeenCalledWith({ state: NgxGraphStates.Output });
@@ -255,6 +292,8 @@ describe('GraphComponent drawComplete', () => {
     (graph as any)._oldLinks = graph.graph.edges.map((e: Edge) => ({ ...e, points: [...(e.points ?? [])] }));
     (graph as any).tick();
     expect(graph.oldNodes.has('n3')).toBe(true);
+
+    drainLayoutTicks();
   }));
 });
 
@@ -603,6 +642,10 @@ describe('GraphComponent stream inputs from the host', () => {
     tick(16);
     fixture.detectChanges();
     flush();
+    for (let i = 0; i < 12; i++) {
+      tick(16);
+      flush();
+    }
 
     const host = fixture.componentInstance;
     fixture.destroy();

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
@@ -120,7 +120,7 @@ class TestGraphDrawCompleteHostComponent {
     { id: 'n2', label: 'B' }
   ];
   clusters: ClusterNode[] = [{ id: 'cl1', label: 'Cluster' }];
-  compoundNodes: CompoundNode[] = [{ id: 'cp1', label: 'Compound', childNodeIds: ['n1'] }];
+  compoundNodes: CompoundNode[] = [];
   links: Edge[] = [{ id: 'e1', source: 'n1', target: 'n2' }];
 
   drawCompleteCount = 0;
@@ -137,6 +137,31 @@ class TestGraphDrawCompleteHostComponent {
   }
 }
 
+@Component({
+  selector: 'test-graph-draw-complete-compound-host',
+  template: `
+    <ngx-graph
+      [nodes]="nodes"
+      [compoundNodes]="compoundNodes"
+      [links]="links"
+      [layout]="syncLayout"
+      [view]="[800, 600]"
+      [animate]="false"
+    ></ngx-graph>
+  `,
+  imports: [GraphComponent]
+})
+class TestGraphDrawCompleteCompoundHostComponent {
+  syncLayout = new TestSyncLayout();
+
+  nodes: Node[] = [
+    { id: 'n1', label: 'A' },
+    { id: 'n2', label: 'B' }
+  ];
+  compoundNodes: CompoundNode[] = [{ id: 'cp1', label: 'Compound', childNodeIds: ['n1'] }];
+  links: Edge[] = [{ id: 'e1', source: 'n1', target: 'n2' }];
+}
+
 describe('GraphComponent drawComplete', () => {
   /** Drain post-tick rAF retries before fakeAsync exits (ngOnChanges + ngAfterViewInit setTimeout updates). */
   function drainLayoutTicks(): void {
@@ -148,23 +173,15 @@ describe('GraphComponent drawComplete', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TestGraphDrawCompleteHostComponent, GraphComponent],
+      imports: [TestGraphDrawCompleteHostComponent, TestGraphDrawCompleteCompoundHostComponent, GraphComponent],
       providers: [LayoutService]
     }).compileComponents();
   });
 
-  it('binds link paths and dimensions for nodes, clusters, and compound nodes', fakeAsync(() => {
-    const fixture = TestBed.createComponent(TestGraphDrawCompleteHostComponent);
-    fixture.detectChanges();
-    flush();
-    tick(16);
-    fixture.detectChanges();
-    flush();
-    drainLayoutTicks();
-
-    const graphEl = fixture.debugElement.query(By.directive(GraphComponent));
-    const graph = graphEl.componentInstance as GraphComponent;
-
+  function assertLinkPathsAndBBoxMatchModel(
+    fixture: ComponentFixture<TestGraphDrawCompleteHostComponent | TestGraphDrawCompleteCompoundHostComponent>,
+    graph: GraphComponent
+  ): void {
     expect(graph.graph.nodes.length).toBeGreaterThan(0);
     expect(graph.graph.edges.length).toBe(1);
     expect(graph.linkElements()?.length ?? 0).toBe(graph.graph.edges.length);
@@ -192,6 +209,32 @@ describe('GraphComponent drawComplete', () => {
     graph.graph.clusters?.forEach(c => assertBBoxMatchesModel(c.id, c));
     graph.graph.compoundNodes?.forEach(c => assertBBoxMatchesModel(c.id, c));
     expect(graph.hasDims()).toBe(true);
+  }
+
+  it('binds link paths and dimensions for nodes and clusters', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphDrawCompleteHostComponent);
+    fixture.detectChanges();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+    drainLayoutTicks();
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    assertLinkPathsAndBBoxMatchModel(fixture, graph);
+  }));
+
+  it('binds link paths and dimensions for nodes and compound nodes', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphDrawCompleteCompoundHostComponent);
+    fixture.detectChanges();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+    drainLayoutTicks();
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    assertLinkPathsAndBBoxMatchModel(fixture, graph);
   }));
 
   it('emits drawComplete and stateChange Output when layout output is finalized', fakeAsync(() => {
@@ -550,6 +593,75 @@ describe('GraphComponent graph data and layout behavior', () => {
 
     const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
     expect(graph.hasGraphDims()).toBe(true);
+    expect(graph.hasDims()).toBe(true);
+  }));
+
+  it('hasDims returns false when clusters input is bound but graph.clusters is still empty', fakeAsync(() => {
+    const fixture = TestBed.createComponent(GraphComponent);
+    const graph = fixture.componentInstance;
+    fixture.componentRef.setInput('layout', new TestSyncLayout());
+    fixture.componentRef.setInput('view', [400, 300]);
+    fixture.componentRef.setInput('animate', false);
+    fixture.componentRef.setInput('nodes', [{ id: 'n1', label: 'A', dimension: { width: 48, height: 32 } }]);
+    fixture.componentRef.setInput('clusters', [{ id: 'c1', label: 'Cluster' }]);
+    fixture.componentRef.setInput('links', []);
+    fixture.detectChanges();
+
+    (graph as any).graph = {
+      nodes: [{ id: 'n1', label: 'A', dimension: { width: 48, height: 32 } }],
+      edges: [],
+      clusters: [],
+      compoundNodes: []
+    };
+    (graph as any).graphDims = { width: 400, height: 300 };
+
+    expect(graph.hasNodeDims()).toBe(true);
+    expect(graph.hasClusterDims()).toBe(false);
+    expect(graph.hasDims()).toBe(false);
+  }));
+
+  it('hasDims returns false when compoundNodes input is bound but graph.compoundNodes is still empty', fakeAsync(() => {
+    const fixture = TestBed.createComponent(GraphComponent);
+    const graph = fixture.componentInstance;
+    fixture.componentRef.setInput('layout', new TestSyncLayout());
+    fixture.componentRef.setInput('view', [400, 300]);
+    fixture.componentRef.setInput('animate', false);
+    fixture.componentRef.setInput('nodes', [{ id: 'n1', label: 'A', dimension: { width: 48, height: 32 } }]);
+    fixture.componentRef.setInput('compoundNodes', [{ id: 'cp1', label: 'Compound', childNodeIds: ['n1'] }]);
+    fixture.componentRef.setInput('links', []);
+    fixture.detectChanges();
+
+    (graph as any).graph = {
+      nodes: [{ id: 'n1', label: 'A', dimension: { width: 48, height: 32 } }],
+      edges: [],
+      clusters: [],
+      compoundNodes: []
+    };
+    (graph as any).graphDims = { width: 400, height: 300 };
+
+    expect(graph.hasNodeDims()).toBe(true);
+    expect(graph.hasCompoundNodeDims()).toBe(false);
+    expect(graph.hasDims()).toBe(false);
+  }));
+
+  it('hasDims returns true for nodes-only graphs without cluster or compound inputs', fakeAsync(() => {
+    const fixture = TestBed.createComponent(GraphComponent);
+    const graph = fixture.componentInstance;
+    fixture.componentRef.setInput('layout', new TestSyncLayout());
+    fixture.componentRef.setInput('view', [400, 300]);
+    fixture.componentRef.setInput('animate', false);
+    fixture.componentRef.setInput('nodes', [{ id: 'n1', label: 'A', dimension: { width: 48, height: 32 } }]);
+    fixture.componentRef.setInput('links', []);
+    fixture.detectChanges();
+
+    (graph as any).graph = {
+      nodes: [{ id: 'n1', label: 'A', dimension: { width: 48, height: 32 } }],
+      edges: [],
+      clusters: [],
+      compoundNodes: []
+    };
+    (graph as any).graphDims = { width: 400, height: 300 };
+
     expect(graph.hasDims()).toBe(true);
   }));
 

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
@@ -107,6 +107,7 @@ class TestLayoutWithCustomParseTranslate extends TestSyncLayout {
       [view]="[800, 600]"
       [animate]="false"
       (drawComplete)="onDrawComplete()"
+      (stateChange)="onStateChange($event)"
     ></ngx-graph>
   `,
   imports: [GraphComponent]
@@ -123,9 +124,16 @@ class TestGraphDrawCompleteHostComponent {
   links: Edge[] = [{ id: 'e1', source: 'n1', target: 'n2' }];
 
   drawCompleteCount = 0;
+  outputStateCount = 0;
 
   onDrawComplete(): void {
     this.drawCompleteCount++;
+  }
+
+  onStateChange(event: { state: NgxGraphStates }): void {
+    if (event.state === NgxGraphStates.Output) {
+      this.outputStateCount++;
+    }
   }
 }
 
@@ -145,15 +153,14 @@ describe('GraphComponent drawComplete', () => {
     tick(16);
     fixture.detectChanges();
     flush();
-    tick(1000);
-    fixture.detectChanges();
-    flush();
 
     expect(host.drawCompleteCount).toBe(1);
+    expect(host.outputStateCount).toBeGreaterThanOrEqual(1);
 
     const graphEl = fixture.debugElement.query(By.directive(GraphComponent));
     const graph = graphEl.componentInstance as GraphComponent;
 
+    expect(graph.graph.nodes.length).toBeGreaterThan(0);
     expect(graph.graph.edges.length).toBe(1);
     expect(graph.linkElements()?.length ?? 0).toBe(graph.graph.edges.length);
 
@@ -179,6 +186,51 @@ describe('GraphComponent drawComplete', () => {
     graph.graph.nodes.forEach(n => assertBBoxMatchesModel(n.id, n));
     graph.graph.clusters?.forEach(c => assertBBoxMatchesModel(c.id, c));
     graph.graph.compoundNodes?.forEach(c => assertBBoxMatchesModel(c.id, c));
+  }));
+
+  it('emits drawComplete once but stateChange Output on each ready layout update', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphDrawCompleteHostComponent);
+    const host = fixture.componentInstance;
+    fixture.detectChanges();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+
+    expect(host.drawCompleteCount).toBe(1);
+    const outputAfterFirst = host.outputStateCount;
+
+    host.nodes = [...host.nodes, { id: 'n3', label: 'C' }];
+    host.links = [...host.links, { id: 'e2', source: 'n2', target: 'n3' }];
+    fixture.detectChanges();
+    flush();
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    graph.update();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+
+    expect(host.drawCompleteCount).toBe(1);
+    expect(host.outputStateCount).toBeGreaterThan(outputAfterFirst);
+  }));
+
+  it('does not emit drawComplete or Output when nodes and links are empty', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphEmptyViewHostComponent);
+    fixture.detectChanges();
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    const drawSpy = jasmine.createSpy('drawCompleteSpy');
+    const stateSpy = jasmine.createSpy('stateSpy');
+    graph.drawComplete.subscribe(drawSpy);
+    graph.stateChange.subscribe(stateSpy);
+
+    flush();
+    tick(5000);
+    fixture.detectChanges();
+    flush();
+
+    expect(drawSpy).not.toHaveBeenCalled();
+    expect(stateSpy).not.toHaveBeenCalledWith({ state: NgxGraphStates.Output });
   }));
 
   it('tick assigns oldNodes for newly added ids synchronously before post-tick rAF', fakeAsync(() => {

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -236,6 +236,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
 
   /** Latest requestAnimationFrame id per edge for imperative path morphing (cancel on layout / drag). */
   private readonly edgePathRafIds = new Map<string, number>();
+  /** Per-edge session id; bumped when that edge's morph is cancelled or restarted. */
+  private readonly edgePathMorphGeneration = new Map<string, number>();
 
   /**
    * Stable {@link NgTemplateOutlet} context objects keyed by graph id so consumer templates (tooltips, nested
@@ -261,6 +263,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
 
   /** Single rAF when layout morph unifies node transforms + edge paths. */
   private layoutUnifiedRafId: number | null = null;
+  /** Bumped when unified layout morph is cancelled so stale rAF steps cannot finalize the current tick. */
+  private layoutUnifiedMorphGeneration = 0;
 
   /** rAF for programmatic viewport pan easing (translation only). */
   private viewportPanAnimRafId: number | null = null;
@@ -2384,25 +2388,50 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     return true;
   }
 
+  private edgePathMorphGen(edgeKey: string): number {
+    return this.edgePathMorphGeneration.get(edgeKey) ?? 0;
+  }
+
+  private bumpEdgePathMorphGeneration(edgeKey: string): number {
+    const next = this.edgePathMorphGen(edgeKey) + 1;
+    this.edgePathMorphGeneration.set(edgeKey, next);
+    return next;
+  }
+
+  /** Drop a superseded edge morph step and release its rAF slot so readiness can proceed. */
+  private abandonStaleEdgePathMorphStep(edgeKey: string, morphGeneration: number): boolean {
+    if (morphGeneration === this.edgePathMorphGen(edgeKey)) {
+      return false;
+    }
+    this.edgePathRafIds.delete(edgeKey);
+    return true;
+  }
+
   private cancelEdgePathAnimation(edgeId: string): void {
     const rafId = this.edgePathRafIds.get(edgeId);
     if (rafId != null) {
       cancelAnimationFrame(rafId);
       this.edgePathRafIds.delete(edgeId);
+      this.bumpEdgePathMorphGeneration(edgeId);
     }
   }
 
   private cancelAllEdgePathAnimations(): void {
+    const edgeKeys = [...this.edgePathRafIds.keys()];
     for (const rafId of this.edgePathRafIds.values()) {
       cancelAnimationFrame(rafId);
     }
     this.edgePathRafIds.clear();
+    for (const edgeKey of edgeKeys) {
+      this.bumpEdgePathMorphGeneration(edgeKey);
+    }
   }
 
   private cancelLayoutUnifiedAnimation(): void {
     if (this.layoutUnifiedRafId != null) {
       cancelAnimationFrame(this.layoutUnifiedRafId);
       this.layoutUnifiedRafId = null;
+      this.layoutUnifiedMorphGeneration++;
     }
   }
 
@@ -2429,6 +2458,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     const dimTgts = this.layoutAnimationClusterCompoundDimensions;
     const easeFn = resolveGraphTransitionEasing(this.effectiveLayoutTransition.easing);
     const skipNodePositionTween = this.effectiveLayoutTransition.scope === 'additive';
+    const morphTickId = this.drawCompleteTickId;
+    const morphGeneration = ++this.layoutUnifiedMorphGeneration;
 
     this.zone.runOutsideAngular(() => {
       for (const m of edgeMorphs) {
@@ -2487,6 +2518,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
       };
 
       const step = () => {
+        if (this._graphDestroyed || morphGeneration !== this.layoutUnifiedMorphGeneration) {
+          return;
+        }
         const elapsed = performance.now() - startMs;
         const u = durationMs <= 0 ? 1 : Math.min(1, elapsed / durationMs);
         const tscalar = easeFn(u);
@@ -2509,6 +2543,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
         });
 
         if (u >= 1) {
+          if (morphTickId !== this.drawCompleteTickId || morphGeneration !== this.layoutUnifiedMorphGeneration) {
+            return;
+          }
           this.zone.run(() => {
             if (!skipNodePositionTween) {
               const finalize = (items: Node[] | undefined) => {
@@ -2567,6 +2604,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
           return;
         }
 
+        if (morphGeneration !== this.layoutUnifiedMorphGeneration) {
+          return;
+        }
         this.layoutUnifiedRafId = requestAnimationFrame(step);
       };
 
@@ -2593,6 +2633,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     this.cancelEdgePathAnimation(edgeKey);
 
     const easeFn = resolveGraphTransitionEasing(this.effectiveLayoutTransition.easing);
+    const morphTickId = this.drawCompleteTickId;
+    const morphGeneration = this.bumpEdgePathMorphGeneration(edgeKey);
 
     this.zone.runOutsideAngular(() => {
       pathSelection.attr('d', startLine);
@@ -2603,6 +2645,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
       const startMs = performance.now();
 
       const step = () => {
+        if (this._graphDestroyed || this.abandonStaleEdgePathMorphStep(edgeKey, morphGeneration)) {
+          return;
+        }
         const elapsed = performance.now() - startMs;
         const u = durationMs <= 0 ? 1 : Math.min(1, elapsed / durationMs);
         const t = easeFn(u);
@@ -2614,6 +2659,10 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
         }
 
         if (u >= 1) {
+          if (morphTickId !== this.drawCompleteTickId || morphGeneration !== this.edgePathMorphGen(edgeKey)) {
+            this.edgePathRafIds.delete(edgeKey);
+            return;
+          }
           this.edgePathRafIds.delete(edgeKey);
           this.zone.run(() => {
             edge.previousPoints = undefined;
@@ -2622,6 +2671,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
           return;
         }
 
+        if (this.abandonStaleEdgePathMorphStep(edgeKey, morphGeneration)) {
+          return;
+        }
         const rafId = requestAnimationFrame(step);
         this.edgePathRafIds.set(edgeKey, rafId);
       };

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -231,6 +231,11 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   /** True after the first {@link drawComplete} emission for this component instance. */
   private drawCompleteEmitted = false;
   private static readonly TICK_FINALIZE_MAX_RETRIES = 5;
+  /** Extra afterNextRender passes when bounded retries exhaust but the same tick may still become ready. */
+  private static readonly TICK_FINALIZE_DEFERRED_MAX_RETRIES = 5;
+  /** Tick id for which passive finalize checks are armed after {@link TICK_FINALIZE_MAX_RETRIES}. */
+  private drawCompleteDeferredTickId: number | null = null;
+  private drawCompleteDeferredRetryDepth = 0;
   private _graphDestroyed = false;
   private destroy$ = new Subject<void>();
 
@@ -2280,6 +2285,101 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
         latestTickId: this.drawCompleteTickId
       });
     }
+    if (tickId === this.drawCompleteTickId && this.canTickEmitDrawComplete(tickId)) {
+      this.armDeferredDrawCompleteCheck(tickId);
+    }
+  }
+
+  /** False when host inputs are empty — {@link isGraphDrawReady} cannot pass on this tick. */
+  private canTickEmitDrawComplete(tickId: number): boolean {
+    if (tickId !== this.drawCompleteTickId) {
+      return false;
+    }
+    const inputNodeCount = this.nodes()?.length ?? 0;
+    const inputLinkCount = this.links()?.length ?? 0;
+    return !(inputNodeCount === 0 && inputLinkCount === 0);
+  }
+
+  /** Arm passive finalize checks for `tickId` after bounded {@link tryRedrawLinesAfterView} retries exhaust. */
+  private armDeferredDrawCompleteCheck(tickId: number): void {
+    if (tickId !== this.drawCompleteTickId) {
+      return;
+    }
+    this.drawCompleteDeferredTickId = tickId;
+    this.drawCompleteDeferredRetryDepth = 0;
+    this.scheduleDeferredDrawCompleteCheck(tickId);
+  }
+
+  private clearDeferredDrawCompleteCheck(): void {
+    this.drawCompleteDeferredTickId = null;
+    this.drawCompleteDeferredRetryDepth = 0;
+  }
+
+  private scheduleDeferredDrawCompleteCheck(tickId: number): void {
+    if (
+      this._graphDestroyed ||
+      tickId !== this.drawCompleteTickId ||
+      this.drawCompleteDeferredTickId !== tickId
+    ) {
+      return;
+    }
+    requestAnimationFrame(() => {
+      if (
+        this._graphDestroyed ||
+        tickId !== this.drawCompleteTickId ||
+        this.drawCompleteDeferredTickId !== tickId
+      ) {
+        return;
+      }
+      afterNextRender(
+        () => {
+          this.tryDeferredDrawCompleteCheck(tickId);
+        },
+        { injector: this.injector }
+      );
+    });
+  }
+
+  /**
+   * Passive readiness pass after morph or DOM settles on the same tick.
+   */
+  private tryDeferredDrawCompleteCheck(tickId: number): void {
+    if (
+      this._graphDestroyed ||
+      tickId !== this.drawCompleteTickId ||
+      this.drawCompleteDeferredTickId !== tickId
+    ) {
+      return;
+    }
+    if (this.layoutUnifiedRafId != null || this.edgePathRafIds.size > 0) {
+      return;
+    }
+    this.maybeFinalizeTickOutput(tickId);
+    if (this.drawCompleteDeferredTickId !== tickId) {
+      return;
+    }
+    if (!this.canTickEmitDrawComplete(tickId)) {
+      this.clearDeferredDrawCompleteCheck();
+      return;
+    }
+    if (this.drawCompleteDeferredRetryDepth >= GraphComponent.TICK_FINALIZE_DEFERRED_MAX_RETRIES) {
+      this.clearDeferredDrawCompleteCheck();
+      return;
+    }
+    this.drawCompleteDeferredRetryDepth++;
+    this.scheduleDeferredDrawCompleteCheck(tickId);
+  }
+
+  /** Re-arm passive checks after morph completes when bounded retries already deferred this tick. */
+  private resumeDeferredDrawCompleteCheckIfNeeded(tickId: number): void {
+    if (
+      this.drawCompleteDeferredTickId === tickId &&
+      tickId === this.drawCompleteTickId &&
+      this.layoutUnifiedRafId == null &&
+      this.edgePathRafIds.size === 0
+    ) {
+      this.scheduleDeferredDrawCompleteCheck(tickId);
+    }
   }
 
   /**
@@ -2293,6 +2393,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     if (!this.isGraphDrawReady(tickId)) {
       return;
     }
+    this.clearDeferredDrawCompleteCheck();
     this.stateChange.emit({ state: NgxGraphStates.Output });
     if (!this.drawCompleteEmitted) {
       this.drawComplete.emit();
@@ -2601,6 +2702,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
           });
           this.layoutUnifiedRafId = null;
           this.maybeFinalizeTickOutput(this.drawCompleteTickId);
+          this.resumeDeferredDrawCompleteCheckIfNeeded(morphTickId);
           return;
         }
 
@@ -2667,6 +2769,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
           this.zone.run(() => {
             edge.previousPoints = undefined;
             this.maybeFinalizeTickOutput(this.drawCompleteTickId);
+            this.resumeDeferredDrawCompleteCheckIfNeeded(morphTickId);
           });
           return;
         }
@@ -3722,7 +3825,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    */
   public hasCompoundNodeDims(): boolean {
     if (!this.graph?.compoundNodes?.length) {
-      return true;
+      return (this.compoundNodes()?.length ?? 0) === 0;
     }
     return this.graph.compoundNodes.every(
       node => (node.dimension?.width ?? 0) > 0 && (node.dimension?.height ?? 0) > 0
@@ -3734,7 +3837,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    */
   public hasClusterDims(): boolean {
     if (!this.graph?.clusters?.length) {
-      return true;
+      return (this.clusters()?.length ?? 0) === 0;
     }
     return this.graph.clusters.every(node => (node.dimension?.width ?? 0) > 0 && (node.dimension?.height ?? 0) > 0);
   }
@@ -3749,12 +3852,10 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     if (!this.hasGraphDims() || !this.hasNodeDims()) {
       return false;
     }
-    const hasCompounds = (this.compoundNodes()?.length ?? 0) > 0;
-    const hasClusters = (this.clusters()?.length ?? 0) > 0;
-    if (hasCompounds && !this.hasCompoundNodeDims()) {
+    if ((this.compoundNodes()?.length ?? 0) > 0 && !this.hasCompoundNodeDims()) {
       return false;
     }
-    if (hasClusters && !this.hasClusterDims()) {
+    if ((this.clusters()?.length ?? 0) > 0 && !this.hasClusterDims()) {
       return false;
     }
     return true;

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -213,9 +213,6 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   oldNodes: Set<string> = new Set();
   oldClusters: Set<string> = new Set();
   oldCompoundNodes: Set<string> = new Set();
-  /** Incremented at the start of each {@link tick}; completion callbacks only emit when this matches. */
-  private drawCompleteTickId = 0;
-  private _graphDestroyed = false;
   transformationMatrix: Matrix = identity();
   _touchLastX = null;
   _touchLastY = null;
@@ -229,7 +226,12 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   height: number;
   resizeSubscription: any;
   visibilityObserver: VisibilityObserver;
-  private waitForGraphDims: ReturnType<typeof setInterval>;
+  /** Incremented at the start of each {@link tick}; completion callbacks only emit when this matches. */
+  private drawCompleteTickId = 0;
+  /** True after the first {@link drawComplete} emission for this component instance. */
+  private drawCompleteEmitted = false;
+  private static readonly TICK_FINALIZE_MAX_RETRIES = 5;
+  private _graphDestroyed = false;
   private destroy$ = new Subject<void>();
 
   /** Latest requestAnimationFrame id per edge for imperative path morphing (cancel on layout / drag). */
@@ -476,13 +478,6 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
       });
     }
 
-    this.waitForGraphDims = setInterval(() => {
-      if (this.hasDims()) {
-        clearInterval(this.waitForGraphDims);
-        this.drawComplete.emit();
-      }
-    }, 1000);
-
     this.minimapClipPathId = `minimapClip${id()}`;
     this.stateChange.emit({ state: NgxGraphStates.Subscribe });
   }
@@ -541,9 +536,6 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     if (this.visibilityObserver) {
       this.visibilityObserver.visible.unsubscribe();
       this.visibilityObserver.destroy();
-    }
-    if (this.waitForGraphDims) {
-      clearInterval(this.waitForGraphDims);
     }
     this.destroy$.next();
     this.destroy$.complete();
@@ -2183,8 +2175,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
 
   /**
    * Runs after Angular commits the template so D3 binds to the live link `<path>` elements
-   * (OnPush + rAF alone can run too early). Retries once after `requestAnimationFrame` if link
-   * groups are not ready yet — avoids two immediate `afterNextRender` passes that cancel unified RAF.
+   * (OnPush + rAF alone can run too early). Retries with bounded `afterNextRender` passes until
+   * {@link isGraphDrawReady} — avoids finalizing before link paths and dimensions are bound.
    */
   private scheduleRedrawLinesAfterView(morph: boolean, tickId: number): void {
     afterNextRender(
@@ -2229,13 +2221,13 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
 
   /**
    * Binds D3 to link `<path>` elements, then emits {@link stateChange} (Output) and {@link drawComplete}
-   * when link groups match edge count (or after bounded retries).
+   * when {@link isGraphDrawReady} passes (paths bound, model positions/dims reflected).
    *
    * Observable layouts (Cola, D3 force) can emit faster than `afterNextRender`; callbacks may run with a
    * superseded `tickId`. Those passes must not call {@link redrawLines} with morph enabled — it would
    * {@link cancelLayoutUnifiedAnimation} and interrupt full-graph layout morphs. Instead, repaint paths
    * from the current model when no rAF tween owns the paths; the latest `tickId` still runs full {@link redrawLines}.
-   * {@link finalizeTickOutput} alone enforces `drawCompleteTickId`.
+   * {@link finalizeTickOutput} alone enforces `drawCompleteTickId` and readiness.
    */
   private tryRedrawLinesAfterView(morph: boolean, retryDepth: number, tickId: number): void {
     if (this._graphDestroyed) {
@@ -2247,14 +2239,11 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     } else if (this.layoutUnifiedRafId == null && this.edgePathRafIds.size === 0) {
       this.repaintLinkPathsDomFromModel();
     }
-    const expected = this.graph.edges?.length ?? 0;
-    const got = this.linkElements()?.length ?? 0;
-    const linksReady = expected === 0 || got === expected;
-    if (linksReady) {
+    if (this.isGraphDrawReady(tickId)) {
       this.finalizeTickOutput(tickId);
       return;
     }
-    if (retryDepth < 2) {
+    if (retryDepth < GraphComponent.TICK_FINALIZE_MAX_RETRIES) {
       requestAnimationFrame(() => {
         afterNextRender(
           () => {
@@ -2266,19 +2255,121 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
       return;
     }
     if (isDevMode()) {
-      console.warn(
-        '[ngx-graph] Link group count did not match edge count after retries; emitting drawComplete anyway.',
-        { expected, got }
-      );
+      const expected = this.graph?.edges?.length ?? 0;
+      const got = this.linkElements()?.length ?? 0;
+      console.warn('[ngx-graph] Graph not ready after retries; deferring stateChange and drawComplete.', {
+        expected,
+        got,
+        tickId,
+        latestTickId: this.drawCompleteTickId
+      });
     }
-    this.finalizeTickOutput(tickId);
   }
 
+  /**
+   * Emits {@link stateChange} Output and first-load {@link drawComplete} when the internal graph model and
+   * DOM reflect layout readiness for `tickId`.
+   */
   private finalizeTickOutput(tickId: number): void {
     if (this._graphDestroyed || tickId !== this.drawCompleteTickId) {
       return;
     }
+    if (!this.isGraphDrawReady(tickId)) {
+      return;
+    }
     this.stateChange.emit({ state: NgxGraphStates.Output });
+    if (!this.drawCompleteEmitted) {
+      this.drawComplete.emit();
+      this.drawCompleteEmitted = true;
+    }
+  }
+
+  /** Attempt finalize when async morph completes after an earlier tick pass deferred emission. */
+  private maybeFinalizeTickOutput(tickId: number): void {
+    if (this.isGraphDrawReady(tickId)) {
+      this.finalizeTickOutput(tickId);
+    }
+  }
+
+  /**
+   * True when `tickId` is the latest tick and the internal {@link graph} plus bound link paths match host inputs
+   * (positions, dimensions, edges) — safe point for {@link drawComplete} and Output {@link stateChange}.
+   */
+  private isGraphDrawReady(tickId: number): boolean {
+    if (tickId !== this.drawCompleteTickId || !this.initialized || !this.graph) {
+      return false;
+    }
+    if (this.layoutUnifiedRafId != null || this.edgePathRafIds.size > 0) {
+      return false;
+    }
+    const inputNodeCount = this.nodes()?.length ?? 0;
+    const inputLinkCount = this.links()?.length ?? 0;
+    if (inputNodeCount === 0 && inputLinkCount === 0) {
+      return false;
+    }
+    if (inputNodeCount > 0 && !(this.graph.nodes?.length > 0)) {
+      return false;
+    }
+    if (inputLinkCount > 0 && !(this.graph.edges?.length > 0)) {
+      return false;
+    }
+    const inputClusterCount = this.clusters()?.length ?? 0;
+    const inputCompoundCount = this.compoundNodes()?.length ?? 0;
+    if (inputClusterCount > 0 && !(this.graph.clusters?.length > 0)) {
+      return false;
+    }
+    if (inputCompoundCount > 0 && !(this.graph.compoundNodes?.length > 0)) {
+      return false;
+    }
+    if (
+      !this.areNodeLikePositionsReady(this.graph.nodes) ||
+      !this.areNodeLikePositionsReady(this.graph.clusters) ||
+      !this.areNodeLikePositionsReady(this.graph.compoundNodes)
+    ) {
+      return false;
+    }
+    if (!this.hasDims() || !this.areLinkPathsBound()) {
+      return false;
+    }
+    return true;
+  }
+
+  /** Nodes/clusters/compounds are not still hidden at bootstrap origin waiting for layout. */
+  private areNodeLikePositionsReady(items: Node[] | undefined): boolean {
+    if (!items?.length) {
+      return true;
+    }
+    for (const n of items) {
+      if (!n.position) {
+        return false;
+      }
+      const atOrigin = (n.position.x ?? 0) === 0 && (n.position.y ?? 0) === 0;
+      if (atOrigin && n.hidden) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Link `<path>` groups exist for every edge and each path has a non-empty `d`. */
+  private areLinkPathsBound(): boolean {
+    const expected = this.graph?.edges?.length ?? 0;
+    if (expected === 0) {
+      return (this.links()?.length ?? 0) === 0;
+    }
+    const linkEls = this.linkElements() ?? [];
+    if (linkEls.length !== expected) {
+      return false;
+    }
+    for (const linkRef of linkEls) {
+      const g = linkRef.nativeElement as SVGGElement;
+      const path = g.querySelector('path.edge, path.line') ?? g.querySelector('path');
+      const d = path?.getAttribute('d');
+      if (!d || d.length === 0) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private cancelEdgePathAnimation(edgeId: string): void {
@@ -2460,6 +2551,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
             }
           });
           this.layoutUnifiedRafId = null;
+          this.maybeFinalizeTickOutput(this.drawCompleteTickId);
           return;
         }
 
@@ -2513,6 +2605,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
           this.edgePathRafIds.delete(edgeKey);
           this.zone.run(() => {
             edge.previousPoints = undefined;
+            this.maybeFinalizeTickOutput(this.drawCompleteTickId);
           });
           return;
         }
@@ -3554,33 +3647,53 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    * Checks if all nodes have dimension
    */
   public hasNodeDims(): boolean {
-    return this.graph.nodes?.every(node => node.dimension.width > 0 && node.dimension.height > 0);
+    if (!this.graph?.nodes?.length) {
+      return (this.nodes()?.length ?? 0) === 0;
+    }
+    return this.graph.nodes.every(node => (node.dimension?.width ?? 0) > 0 && (node.dimension?.height ?? 0) > 0);
   }
 
   /**
    * Checks if all compound nodes have dimension
    */
   public hasCompoundNodeDims(): boolean {
-    return this.graph.compoundNodes?.every(node => node.dimension.width > 0 && node.dimension.height > 0);
+    if (!this.graph?.compoundNodes?.length) {
+      return true;
+    }
+    return this.graph.compoundNodes.every(
+      node => (node.dimension?.width ?? 0) > 0 && (node.dimension?.height ?? 0) > 0
+    );
   }
 
   /**
    * Checks if all clusters have dimension
    */
   public hasClusterDims(): boolean {
-    return this.graph.clusters?.every(node => node.dimension.width > 0 && node.dimension.height > 0);
+    if (!this.graph?.clusters?.length) {
+      return true;
+    }
+    return this.graph.clusters.every(node => (node.dimension?.width ?? 0) > 0 && (node.dimension?.height ?? 0) > 0);
   }
 
   /**
    * Checks if the graph and all nodes have dimension.
    */
   public hasDims(): boolean {
-    return (
-      this.hasGraphDims() &&
-      this.hasNodeDims() &&
-      ((this.compoundNodes()?.length ? this.hasCompoundNodeDims() : true) ||
-        (this.clusters()?.length ? this.hasClusterDims() : true))
-    );
+    if (!this.graph) {
+      return false;
+    }
+    if (!this.hasGraphDims() || !this.hasNodeDims()) {
+      return false;
+    }
+    const hasCompounds = (this.compoundNodes()?.length ?? 0) > 0;
+    const hasClusters = (this.clusters()?.length ?? 0) > 0;
+    if (hasCompounds && !this.hasCompoundNodeDims()) {
+      return false;
+    }
+    if (hasClusters && !this.hasClusterDims()) {
+      return false;
+    }
+    return true;
   }
 
   protected unbindEvents(): void {

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -1776,6 +1776,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     this.oldCompoundNodes = newCompoundNodeIds;
 
     requestAnimationFrame(() => {
+      if (this._graphDestroyed) {
+        return;
+      }
       // Full-scope morph keeps `node.transform` at previous layout until unified rAF; do not sync from `position` or
       // refresh bounds/pan from the new layout here — that would wipe `resetToPrevious` and desync the viewport.
       const nodeTweenActive =
@@ -2179,8 +2182,14 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    * {@link isGraphDrawReady} — avoids finalizing before link paths and dimensions are bound.
    */
   private scheduleRedrawLinesAfterView(morph: boolean, tickId: number): void {
+    if (this._graphDestroyed || tickId !== this.drawCompleteTickId) {
+      return;
+    }
     afterNextRender(
       () => {
+        if (this._graphDestroyed) {
+          return;
+        }
         this.tryRedrawLinesAfterView(morph, 0, tickId);
       },
       { injector: this.injector }
@@ -2241,6 +2250,9 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     }
     if (this.isGraphDrawReady(tickId)) {
       this.finalizeTickOutput(tickId);
+      return;
+    }
+    if (tickId !== this.drawCompleteTickId) {
       return;
     }
     if (retryDepth < GraphComponent.TICK_FINALIZE_MAX_RETRIES) {

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -2316,19 +2316,11 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   }
 
   private scheduleDeferredDrawCompleteCheck(tickId: number): void {
-    if (
-      this._graphDestroyed ||
-      tickId !== this.drawCompleteTickId ||
-      this.drawCompleteDeferredTickId !== tickId
-    ) {
+    if (this._graphDestroyed || tickId !== this.drawCompleteTickId || this.drawCompleteDeferredTickId !== tickId) {
       return;
     }
     requestAnimationFrame(() => {
-      if (
-        this._graphDestroyed ||
-        tickId !== this.drawCompleteTickId ||
-        this.drawCompleteDeferredTickId !== tickId
-      ) {
+      if (this._graphDestroyed || tickId !== this.drawCompleteTickId || this.drawCompleteDeferredTickId !== tickId) {
         return;
       }
       afterNextRender(
@@ -2344,11 +2336,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    * Passive readiness pass after morph or DOM settles on the same tick.
    */
   private tryDeferredDrawCompleteCheck(tickId: number): void {
-    if (
-      this._graphDestroyed ||
-      tickId !== this.drawCompleteTickId ||
-      this.drawCompleteDeferredTickId !== tickId
-    ) {
+    if (this._graphDestroyed || tickId !== this.drawCompleteTickId || this.drawCompleteDeferredTickId !== tickId) {
       return;
     }
     if (this.layoutUnifiedRafId != null || this.edgePathRafIds.size > 0) {

--- a/projects/swimlane/ngx-graph/src/stories/Options.mdx
+++ b/projects/swimlane/ngx-graph/src/stories/Options.mdx
@@ -100,11 +100,11 @@ The graph component accepts a `view` input, which is an array with two numeric e
 
 Methods exist on `GraphComponent` to check if the graph has dimension. This can be useful for waiting to display the entire graph after it has proper dimensions.
 
-| Method              | Description                                                                                                                                                          |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| hasGraphDims        | Returns true when the graph container has dimension.                                                                                                                 |
-| hasNodeDims         | Returns true when every node in the graph has dimension.                                                                                                             |
-| hasCompoundNodeDims | Returns true when every compound node in the graph has dimension.                                                                                                    |
+| Method              | Description                                                                                                                                                                                                |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| hasGraphDims        | Returns true when the graph container has dimension.                                                                                                                                                       |
+| hasNodeDims         | Returns true when every node in the graph has dimension.                                                                                                                                                   |
+| hasCompoundNodeDims | Returns true when every compound node in the graph has dimension.                                                                                                                                          |
 | hasDims             | Returns true when graph bounds and all nodes have positive dimensions, and when the bound grouping input (clusters **or** compound nodes) has dimensions in the model — mutually exclusive grouping modes. |
 
 These methods can be used with the `stateChange @Output` to check when the graph has dimension. Suppose you had `GraphComponent` has a `ViewChild` in a parent `Component`.

--- a/projects/swimlane/ngx-graph/src/stories/Options.mdx
+++ b/projects/swimlane/ngx-graph/src/stories/Options.mdx
@@ -105,7 +105,7 @@ Methods exist on `GraphComponent` to check if the graph has dimension. This can 
 | hasGraphDims        | Returns true when the graph container has dimension.                                                                                                                 |
 | hasNodeDims         | Returns true when every node in the graph has dimension.                                                                                                             |
 | hasCompoundNodeDims | Returns true when every compound node in the graph has dimension.                                                                                                    |
-| hasDims             | Returns true when graph bounds and every relevant node/cluster/compound has positive dimensions (both cluster and compound checks apply when both inputs are bound). |
+| hasDims             | Returns true when graph bounds and all nodes have positive dimensions, and when the bound grouping input (clusters **or** compound nodes) has dimensions in the model — mutually exclusive grouping modes. |
 
 These methods can be used with the `stateChange @Output` to check when the graph has dimension. Suppose you had `GraphComponent` has a `ViewChild` in a parent `Component`.
 

--- a/projects/swimlane/ngx-graph/src/stories/Options.mdx
+++ b/projects/swimlane/ngx-graph/src/stories/Options.mdx
@@ -65,13 +65,13 @@ Equivalent: `graph.enablePan.set(...)`, `graph.enableZoom.set(...)`, and `graph.
 
 ## Outputs
 
-| Event        | Description                                                                                                                                                        |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| activate     | element activation event (mouse enter)                                                                                                                             |
-| deactivate   | element deactivation event (mouse leave)                                                                                                                           |
-| zoomChange   | zoom change event, emits the new zoom level                                                                                                                        |
-| stateChange  | state change event, emits lifecycle events like `init`, `transform`, and `subscribe`                                                                               |
-| drawComplete | emits after a completed draw/tick pass (paths bound, graph ready). Use to hide loading UI or run one-shot center/`zoomToFit` without flashing before first layout. |
+| Event        | Description                                                                                                                                                                                                                                          |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| activate     | element activation event (mouse enter)                                                                                                                                                                                                               |
+| deactivate   | element deactivation event (mouse leave)                                                                                                                                                                                                             |
+| zoomChange   | zoom change event, emits the new zoom level                                                                                                                                                                                                          |
+| stateChange  | lifecycle events: `init`, `transform`, `subscribe`, and **`output`** when a tick finishes and the internal graph model plus bound link paths are ready (same gate as `drawComplete`)                                                                 |
+| drawComplete | emits **once** on the **first** tick that passes the readiness gate (paths bound, positions/dims on `graph`). Use to hide loading UI or run one-shot center/`zoomToFit`. For later layout updates, use `(stateChange)` with `NgxGraphStates.Output`. |
 
 ## Viewport zoom vs `zoomLevel` input
 
@@ -100,12 +100,12 @@ The graph component accepts a `view` input, which is an array with two numeric e
 
 Methods exist on `GraphComponent` to check if the graph has dimension. This can be useful for waiting to display the entire graph after it has proper dimensions.
 
-| Method              | Description                                                                                                                |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| hasGraphDims        | Returns true when the graph container has dimension.                                                                       |
-| hasNodeDims         | Returns true when every node in the graph has dimension.                                                                   |
-| hasCompoundNodeDims | Returns true when every compound node in the graph has dimension.                                                          |
-| hasDims             | Returns true when all of the above methods combined return true. This means entire graph is ready to be drawn and updated. |
+| Method              | Description                                                                                                                                                          |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| hasGraphDims        | Returns true when the graph container has dimension.                                                                                                                 |
+| hasNodeDims         | Returns true when every node in the graph has dimension.                                                                                                             |
+| hasCompoundNodeDims | Returns true when every compound node in the graph has dimension.                                                                                                    |
+| hasDims             | Returns true when graph bounds and every relevant node/cluster/compound has positive dimensions (both cluster and compound checks apply when both inputs are bound). |
 
 These methods can be used with the `stateChange @Output` to check when the graph has dimension. Suppose you had `GraphComponent` has a `ViewChild` in a parent `Component`.
 
@@ -122,7 +122,7 @@ In your template, bind the `stateChange @Output` of `GraphComponent` to a handle
     >
 ```
 
-In this callback, you can check for the `NgxGraphStates.Transform` state. `GraphComponent` emits this particular state whenever the graph is transformed. `NgxGraphStates` is an enum exported from @swimlane/ngx-graph. Upon a transform of the graph, check the graph has dimension with `hasDims()`. When `hasDims()` is `true`, it should be safe to zoom and center the graph on load, since these operations depend on the graph having proper dimensions. Additionally, if the parent `Component` implements a loading indicator (`this.isLoading`), the loading indicator can be removed since the graph is ready to display.
+In this callback, you can check for the `NgxGraphStates.Output` state (preferred after load) or `NgxGraphStates.Transform` when the viewport matrix changes. `GraphComponent` emits **`Output`** when a layout tick completes and the graph is ready (paths bound, model positions/dims reflected). Use `(drawComplete)` for first-load loading UI only; use **`Output`** for post-update hooks. When `hasDims()` is `true` at that point, it should be safe to zoom and center the graph on load. Additionally, if the parent `Component` implements a loading indicator (`this.isLoading`), the loading indicator can be removed on `(drawComplete)` or when `event.state === NgxGraphStates.Output`.
 
 ```javascript
 handleStateChange(event: NgxGraphStateChangeEvent) {

--- a/projects/swimlane/ngx-graph/src/test.ts
+++ b/projects/swimlane/ngx-graph/src/test.ts
@@ -7,7 +7,7 @@ import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@ang
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
-  teardown: { destroyAfterEach: false }
+  teardown: { destroyAfterEach: true }
 });
 
 // Load each spec explicitly — add new files here when you add *.spec.ts under this project.


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

* fix: on draw complete should only fire when all nodes, edges are ready

**What is the current behavior?** (You can also link to an open issue here)

The draw complete event can fire before the graph is actually ready.


**What is the new behavior?**

Draw complete now behaves correctly, firing after first pass.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing and semantics of drawComplete/stateChange outputs and hasDims() behavior; apps that relied on repeated drawComplete or the old polling interval may need to listen for NgxGraphStates.Output instead.
> 
> **Overview**
> Fixes **premature `drawComplete`** by removing the `ngOnInit` `setInterval` that polled `hasDims()` every second and tying **`drawComplete`** and **`stateChange` (`Output`)** to tick finalization only when a new **`isGraphDrawReady`** gate passes (model synced to inputs, positions/dims, bound link paths with non-empty `d`, no active layout/edge morph RAF).
> 
> **`drawComplete`** now fires **once** on the first ready tick; **`Output`** fires on every later ready tick. Topology updates after the first draw no longer re-emit **`drawComplete`**; empty node/link graphs emit neither.
> 
> **`hasDims()`** / **`hasNodeDims()`** / **`hasClusterDims()`** / **`hasCompoundNodeDims()`** are tightened so empty internal lists respect bound inputs and only the active grouping mode (clusters **or** compound nodes) is required.
> 
> Tick finalize uses bounded **`afterNextRender`** retries plus deferred passive checks; layout and per-edge morph animations use **generation** counters so stale RAF steps cannot finalize or block readiness. Docs (**`Options.mdx`**) and tests are expanded accordingly; Karma teardown uses **`destroyAfterEach: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2719a8d50481aca11c317705735c5c661cdd8b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->