### PR TITLE
(release): 12.0.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 12.0.0-alpha.5
+
 - Fix: `drawComplete` and `stateChange` (`Output`) now emit from tick finalization only when the internal graph model and bound link paths are ready (removed `hasDims()` polling in `ngOnInit`). `drawComplete` still fires once on first ready draw; `Output` fires on every subsequent ready tick.
 - Fix: `hasClusterDims()` and `hasCompoundNodeDims()` mirror `hasNodeDims()` when the graph model list is empty (respect bound inputs). `hasDims()` checks dimensions only for the grouping input that is bound (clusters or compound nodes — mutually exclusive modes).
 

--- a/projects/swimlane/ngx-graph/package.json
+++ b/projects/swimlane/ngx-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-graph",
-  "version": "12.0.0-alpha.4",
+  "version": "12.0.0-alpha.5",
   "description": "Graph visualization for angular",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

- Fix: `drawComplete` and `stateChange` (`Output`) now emit from tick finalization only when the internal graph model and bound link paths are ready (removed `hasDims()` polling in `ngOnInit`). `drawComplete` still fires once on first ready draw; `Output` fires on every subsequent ready tick.
- Fix: `hasClusterDims()` and `hasCompoundNodeDims()` mirror `hasNodeDims()` when the graph model list is empty (respect bound inputs). `hasDims()` checks dimensions only for the grouping input that is bound (clusters or compound nodes — mutually exclusive modes).



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version and CHANGELOG metadata change in this PR; no application code is modified in the diff.
> 
> **Overview**
> **Release 12.0.0-alpha.5** — bumps `@swimlane/ngx-graph` from `12.0.0-alpha.4` to `12.0.0-alpha.5` and documents the alpha in **CHANGELOG**.
> 
> The new changelog entry records two graph-component fixes (not shown in this diff): **`drawComplete`** and **`stateChange`** (`Output`) now emit from tick finalization only when the model and link paths are ready, with **`hasDims()`** polling removed from **`ngOnInit`**; **`hasClusterDims()`** / **`hasCompoundNodeDims()`** align with **`hasNodeDims()`** on empty lists, and **`hasDims()`** only checks the bound grouping mode (clusters vs compound nodes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f900b44903b9f7b6c2627d0b7a7346755647ef9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->