### PR TITLE
Container Resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD (unreleased)
 
 - Fix: Graph resizes when its parent container changes size (e.g. side panels, flex layouts) via `ResizeObserver`, matching the previous window-resize `update()` behavior including layout.
+- Enhancement: During animated parent resizes, the SVG viewport syncs each animation frame via `refreshViewportDimensions()` (no layout); debounced `update()` still runs 200ms after resize settles for full relayout.
 - Breaking: `GraphComponent` no longer listens to `window` `resize`; automatic resize requires a parent element whose size reflects layout changes. When `[view]` is set, container resize is not observed (unchanged dimension source).
 
 ## 12.0.0-alpha.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## HEAD (unreleased)
 
-- Fix: Graph resizes when its parent container changes size (e.g. side panels, flex layouts) via `ResizeObserver`, matching the previous window-resize `update()` behavior including layout.
 - Enhancement: During animated parent resizes, the SVG viewport syncs each animation frame via `refreshViewportDimensions()` (no layout); debounced `update()` still runs 200ms after resize settles for full relayout.
 - Breaking: `GraphComponent` no longer listens to `window` `resize`; automatic resize requires a parent element whose size reflects layout changes. When `[view]` is set, container resize is not observed (unchanged dimension source).
+- Fix: Graph resizes when its parent container changes size (e.g. side panels, flex layouts) via `ResizeObserver`, matching the previous window-resize `update()` behavior including layout.
 
 ## 12.0.0-alpha.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (unreleased)
 
+- Fix: Graph resizes when its parent container changes size (e.g. side panels, flex layouts) via `ResizeObserver`, matching the previous window-resize `update()` behavior including layout.
+- Breaking: `GraphComponent` no longer listens to `window` `resize`; automatic resize requires a parent element whose size reflects layout changes. When `[view]` is set, container resize is not observed (unchanged dimension source).
+
 ## 12.0.0-alpha.5
 
 - Fix: `drawComplete` and `stateChange` (`Output`) now emit from tick finalization only when the internal graph model and bound link paths are ready (removed `hasDims()` polling in `ngOnInit`). `drawComplete` still fires once on first ready draw; `Output` fires on every subsequent ready tick.

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
@@ -1755,3 +1755,117 @@ describe('GraphComponent snapAddedNodeIds before resetToPrevious', () => {
     expect(parsed.ty).toBeCloseTo(120, 5);
   }));
 });
+
+@Component({
+  selector: 'test-graph-container-resize-host',
+  template: `
+    <div class="graph-container" [style.width.px]="containerWidth" [style.height.px]="containerHeight">
+      <ngx-graph [nodes]="nodes" [links]="links" [layout]="syncLayout" [animate]="false"></ngx-graph>
+    </div>
+  `,
+  imports: [GraphComponent]
+})
+class TestGraphContainerResizeHostComponent {
+  syncLayout = new TestSyncLayout();
+  containerWidth = 600;
+  containerHeight = 400;
+  nodes: Node[] = [
+    { id: 'n1', label: 'A' },
+    { id: 'n2', label: 'B' }
+  ];
+  links: Edge[] = [{ id: 'e1', source: 'n1', target: 'n2' }];
+}
+
+@Component({
+  selector: 'test-graph-fixed-view-host',
+  template: `<ngx-graph [nodes]="nodes" [links]="links" [layout]="syncLayout" [view]="[800, 600]"></ngx-graph>`,
+  imports: [GraphComponent]
+})
+class TestGraphFixedViewHostComponent {
+  syncLayout = new TestSyncLayout();
+  nodes: Node[] = [{ id: 'n1', label: 'A' }];
+  links: Edge[] = [];
+}
+
+describe('GraphComponent container resize', () => {
+  let resizeObserverCallback: ResizeObserverCallback | undefined;
+  let OriginalResizeObserver: typeof ResizeObserver;
+
+  beforeEach(async () => {
+    OriginalResizeObserver = window.ResizeObserver;
+    resizeObserverCallback = undefined;
+    class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        resizeObserverCallback = callback;
+      }
+      observe(): void {}
+      disconnect(): void {}
+      unobserve(): void {}
+    }
+    (window as any).ResizeObserver = ResizeObserverMock;
+
+    await TestBed.configureTestingModule({
+      imports: [TestGraphContainerResizeHostComponent, TestGraphFixedViewHostComponent],
+      providers: [LayoutService]
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    window.ResizeObserver = OriginalResizeObserver;
+  });
+
+  it('refreshViewportDimensions updates width and height without re-running layout', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphContainerResizeHostComponent);
+    fixture.detectChanges();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    const createGraphSpy = spyOn(graph, 'createGraph').and.callThrough();
+    spyOn(graph, 'getContainerDims').and.returnValue({ width: 960, height: 500 });
+
+    graph.refreshViewportDimensions();
+
+    expect(graph.width).toBe(960);
+    expect(graph.height).toBe(500);
+    expect(createGraphSpy).not.toHaveBeenCalled();
+  }));
+
+  it('observes the parent container and refreshes viewport dimensions on resize', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphContainerResizeHostComponent);
+    fixture.detectChanges();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+
+    expect(resizeObserverCallback).toBeDefined();
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    const createGraphSpy = spyOn(graph, 'createGraph').and.callThrough();
+    spyOn(graph, 'getContainerDims').and.returnValue({ width: 840, height: 400 });
+
+    resizeObserverCallback!([], {} as ResizeObserver);
+    tick(16);
+    fixture.detectChanges();
+
+    expect(graph.width).toBe(840);
+    expect(createGraphSpy).not.toHaveBeenCalled();
+  }));
+
+  it('refreshViewportDimensions is a no-op when [view] supplies explicit dimensions', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphFixedViewHostComponent);
+    fixture.detectChanges();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    graph.refreshViewportDimensions();
+    expect(graph.width).toBe(800);
+    expect(graph.height).toBe(600);
+  }));
+});

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
@@ -1833,7 +1833,7 @@ describe('GraphComponent container resize', () => {
     expect(createGraphSpy).not.toHaveBeenCalled();
   }));
 
-  it('observes the parent container and refreshes viewport dimensions on resize', fakeAsync(() => {
+  it('observes the parent container and runs update on resize', fakeAsync(() => {
     const fixture = TestBed.createComponent(TestGraphContainerResizeHostComponent);
     fixture.detectChanges();
     flush();
@@ -1844,15 +1844,51 @@ describe('GraphComponent container resize', () => {
     expect(resizeObserverCallback).toBeDefined();
 
     const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    const updateSpy = spyOn(graph, 'update').and.callThrough();
     const createGraphSpy = spyOn(graph, 'createGraph').and.callThrough();
     spyOn(graph, 'getContainerDims').and.returnValue({ width: 840, height: 400 });
 
     resizeObserverCallback!([], {} as ResizeObserver);
+    tick(200);
+    fixture.detectChanges();
+    flush();
+
+    expect(updateSpy).toHaveBeenCalled();
+    expect(graph.width).toBe(840);
+    expect(createGraphSpy).toHaveBeenCalled();
+  }));
+
+  it('debounces container resize updates', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphContainerResizeHostComponent);
+    fixture.detectChanges();
+    flush();
     tick(16);
     fixture.detectChanges();
+    flush();
 
-    expect(graph.width).toBe(840);
-    expect(createGraphSpy).not.toHaveBeenCalled();
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    const updateSpy = spyOn(graph, 'update').and.callThrough();
+    spyOn(graph, 'getContainerDims').and.returnValue({ width: 840, height: 400 });
+
+    resizeObserverCallback!([], {} as ResizeObserver);
+    resizeObserverCallback!([], {} as ResizeObserver);
+    resizeObserverCallback!([], {} as ResizeObserver);
+    tick(199);
+    expect(updateSpy).not.toHaveBeenCalled();
+
+    tick(1);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  }));
+
+  it('does not observe container resize when [view] supplies explicit dimensions', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphFixedViewHostComponent);
+    fixture.detectChanges();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+
+    expect(resizeObserverCallback).toBeUndefined();
   }));
 
   it('refreshViewportDimensions is a no-op when [view] supplies explicit dimensions', fakeAsync(() => {

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { Observable, of, Subject } from 'rxjs';
+import { Observable, of, Subject, timer } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { Graph } from '../models/graph.model';
 import { Layout } from '../models/layout.model';
@@ -1800,6 +1801,51 @@ class TestGraphContainerResizeUninitHostComponent {
   syncLayout = new TestSyncLayout();
 }
 
+/** Layout that completes after 500ms to exercise async in-flight cancellation. */
+class TestDelayedLayout implements Layout {
+  run(graph: Graph): Observable<Graph> {
+    return timer(500).pipe(
+      map(() => ({
+        ...graph,
+        nodes: graph.nodes.map((n, i) => ({
+          ...n,
+          position: { x: 120 + i * 100, y: 140 },
+          dimension: { width: n.dimension?.width ?? 48, height: n.dimension?.height ?? 32 }
+        })),
+        edges: graph.edges.map(e => ({
+          ...e,
+          points: [
+            { x: 50, y: 50 },
+            { x: 250, y: 150 }
+          ]
+        }))
+      }))
+    );
+  }
+
+  updateEdge(graph: Graph, _edge: Edge): Graph {
+    return graph;
+  }
+}
+
+@Component({
+  selector: 'test-graph-async-layout-resize-host',
+  template: `
+    <div class="graph-container" [style.width.px]="600" [style.height.px]="400">
+      <ngx-graph [nodes]="nodes" [links]="links" [layout]="delayedLayout" [animate]="false"></ngx-graph>
+    </div>
+  `,
+  imports: [GraphComponent]
+})
+class TestGraphAsyncLayoutResizeHostComponent {
+  delayedLayout = new TestDelayedLayout();
+  nodes: Node[] = [
+    { id: 'n1', label: 'A' },
+    { id: 'n2', label: 'B' }
+  ];
+  links: Edge[] = [{ id: 'e1', source: 'n1', target: 'n2' }];
+}
+
 describe('GraphComponent container resize', () => {
   let resizeObserverCallback: ResizeObserverCallback | undefined;
   let OriginalResizeObserver: typeof ResizeObserver;
@@ -1811,7 +1857,9 @@ describe('GraphComponent container resize', () => {
       constructor(callback: ResizeObserverCallback) {
         resizeObserverCallback = callback;
       }
-      observe(): void {}
+      observe(): void {
+        resizeObserverCallback!([], {} as ResizeObserver);
+      }
       disconnect(): void {}
       unobserve(): void {}
     }
@@ -1821,7 +1869,8 @@ describe('GraphComponent container resize', () => {
       imports: [
         TestGraphContainerResizeHostComponent,
         TestGraphFixedViewHostComponent,
-        TestGraphContainerResizeUninitHostComponent
+        TestGraphContainerResizeUninitHostComponent,
+        TestGraphAsyncLayoutResizeHostComponent
       ],
       providers: [LayoutService]
     }).compileComponents();
@@ -1830,6 +1879,62 @@ describe('GraphComponent container resize', () => {
   afterEach(() => {
     window.ResizeObserver = OriginalResizeObserver;
   });
+
+  function drainGraphInit(fixture: ComponentFixture<unknown>): void {
+    fixture.detectChanges();
+    flush();
+    tick(0);
+    tick(16);
+    fixture.detectChanges();
+    flush();
+  }
+
+  it('does not schedule debounced update from initial observe notification', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphContainerResizeHostComponent);
+    drainGraphInit(fixture);
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    const updateSpy = spyOn(graph, 'update').and.callThrough();
+
+    tick(200);
+    expect(updateSpy).not.toHaveBeenCalled();
+  }));
+
+  it('debounces update when container dimensions change after baseline', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphContainerResizeHostComponent);
+    drainGraphInit(fixture);
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    const updateSpy = spyOn(graph, 'update').and.callThrough();
+    spyOn(graph, 'getContainerDims').and.returnValue({ width: 840, height: 400 });
+
+    resizeObserverCallback!([], {} as ResizeObserver);
+    tick(199);
+    expect(updateSpy).not.toHaveBeenCalled();
+
+    tick(1);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  }));
+
+  it('does not cancel in-flight async layout from initial observe notification', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphAsyncLayoutResizeHostComponent);
+    fixture.detectChanges();
+    flush();
+    tick(0);
+    tick(16);
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    const createGraphSpy = spyOn(graph, 'createGraph').and.callThrough();
+
+    tick(200);
+    expect(createGraphSpy).not.toHaveBeenCalled();
+
+    tick(300);
+    fixture.detectChanges();
+    flush();
+
+    expect(graph.graph.nodes[0].position).toEqual({ x: 120, y: 140 });
+  }));
 
   it('refreshViewportDimensions updates width and height without re-running layout', fakeAsync(() => {
     const fixture = TestBed.createComponent(TestGraphContainerResizeHostComponent);

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.spec.ts
@@ -1787,6 +1787,19 @@ class TestGraphFixedViewHostComponent {
   links: Edge[] = [];
 }
 
+@Component({
+  selector: 'test-graph-container-resize-uninit-host',
+  template: `
+    <div class="graph-container" [style.width.px]="600" [style.height.px]="400">
+      <ngx-graph [layout]="syncLayout"></ngx-graph>
+    </div>
+  `,
+  imports: [GraphComponent]
+})
+class TestGraphContainerResizeUninitHostComponent {
+  syncLayout = new TestSyncLayout();
+}
+
 describe('GraphComponent container resize', () => {
   let resizeObserverCallback: ResizeObserverCallback | undefined;
   let OriginalResizeObserver: typeof ResizeObserver;
@@ -1805,7 +1818,11 @@ describe('GraphComponent container resize', () => {
     (window as any).ResizeObserver = ResizeObserverMock;
 
     await TestBed.configureTestingModule({
-      imports: [TestGraphContainerResizeHostComponent, TestGraphFixedViewHostComponent],
+      imports: [
+        TestGraphContainerResizeHostComponent,
+        TestGraphFixedViewHostComponent,
+        TestGraphContainerResizeUninitHostComponent
+      ],
       providers: [LayoutService]
     }).compileComponents();
   });
@@ -1823,6 +1840,7 @@ describe('GraphComponent container resize', () => {
     flush();
 
     const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    expect(graph.initialized).toBe(true);
     const createGraphSpy = spyOn(graph, 'createGraph').and.callThrough();
     spyOn(graph, 'getContainerDims').and.returnValue({ width: 960, height: 500 });
 
@@ -1831,6 +1849,62 @@ describe('GraphComponent container resize', () => {
     expect(graph.width).toBe(960);
     expect(graph.height).toBe(500);
     expect(createGraphSpy).not.toHaveBeenCalled();
+  }));
+
+  it('refreshViewportDimensions is a no-op before graph is initialized', () => {
+    const fixture = TestBed.createComponent(TestGraphContainerResizeUninitHostComponent);
+    fixture.detectChanges();
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    expect(graph.initialized).toBe(false);
+    const widthBeforeResize = graph.width;
+    spyOn(graph, 'getContainerDims').and.returnValue({ width: 999, height: 500 });
+
+    graph.refreshViewportDimensions();
+
+    expect(graph.width).toBe(widthBeforeResize);
+  });
+
+  it('syncs viewport dimensions on each resize frame before debounced update', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphContainerResizeHostComponent);
+    fixture.detectChanges();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    const updateSpy = spyOn(graph, 'update').and.callThrough();
+    spyOn(graph, 'getContainerDims').and.returnValue({ width: 840, height: 400 });
+
+    resizeObserverCallback!([], {} as ResizeObserver);
+    tick(16);
+
+    expect(graph.width).toBe(840);
+    expect(updateSpy).not.toHaveBeenCalled();
+
+    tick(200);
+    expect(updateSpy).toHaveBeenCalled();
+  }));
+
+  it('coalesces viewport refresh to one RAF per frame', fakeAsync(() => {
+    const fixture = TestBed.createComponent(TestGraphContainerResizeHostComponent);
+    fixture.detectChanges();
+    flush();
+    tick(16);
+    fixture.detectChanges();
+    flush();
+
+    const graph = fixture.debugElement.query(By.directive(GraphComponent)).componentInstance as GraphComponent;
+    const refreshSpy = spyOn(graph, 'refreshViewportDimensions').and.callThrough();
+    spyOn(graph, 'getContainerDims').and.returnValue({ width: 840, height: 400 });
+
+    resizeObserverCallback!([], {} as ResizeObserver);
+    resizeObserverCallback!([], {} as ResizeObserver);
+    resizeObserverCallback!([], {} as ResizeObserver);
+    tick(16);
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
   }));
 
   it('observes the parent container and runs update on resize', fakeAsync(() => {
@@ -1849,12 +1923,14 @@ describe('GraphComponent container resize', () => {
     spyOn(graph, 'getContainerDims').and.returnValue({ width: 840, height: 400 });
 
     resizeObserverCallback!([], {} as ResizeObserver);
+    tick(16);
+    expect(graph.width).toBe(840);
+
     tick(200);
     fixture.detectChanges();
     flush();
 
     expect(updateSpy).toHaveBeenCalled();
-    expect(graph.width).toBe(840);
     expect(createGraphSpy).toHaveBeenCalled();
   }));
 

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -194,10 +194,6 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   readonly clusterElements = viewChildren<ElementRef>('clusterElement');
   readonly linkElements = viewChildren<ElementRef>('linkElement');
 
-  public chartWidth: any;
-
-  private isMouseMoveCalled: boolean = false;
-
   graphSubscription: Subscription = new Subscription();
   colors: ColorHelper;
   dims: ViewDimensions;
@@ -214,8 +210,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   oldClusters: Set<string> = new Set();
   oldCompoundNodes: Set<string> = new Set();
   transformationMatrix: Matrix = identity();
-  _touchLastX = null;
-  _touchLastY = null;
+
   minimapScaleCoefficient: number = 3;
   minimapTransform: string;
   minimapOffsetX: number = 0;
@@ -225,8 +220,13 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   width: number;
   height: number;
   resizeSubscription: any;
-  private containerResizeObserver: ResizeObserver | null = null;
   visibilityObserver: VisibilityObserver;
+
+  private _touchLastX = null;
+  private _touchLastY = null;
+  private isMouseMoveCalled: boolean = false;
+  private containerResizeObserver: ResizeObserver | null = null;
+  private containerResizeRafId: number | null = null;
   /** Incremented at the start of each {@link tick}; completion callbacks only emit when this matches. */
   private drawCompleteTickId = 0;
   /** True after the first {@link drawComplete} emission for this component instance. */
@@ -276,10 +276,10 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   private viewportPanAnimRafId: number | null = null;
 
   /** CSS `transform` on `.ngx-graph-outer` during optional layout flair (perspective / rotate). */
-  layoutOuterTransform: string | null = null;
+  private layoutOuterTransform: string | null = null;
 
   /** `transform-origin` for {@link layoutOuterTransform} when using rotate pivot modes. */
-  layoutEffectTransformOrigin = '50% 50%';
+  private layoutEffectTransformOrigin = '50% 50%';
 
   /** Parsed `translate(tx,ty)` from the graph before a new layout is applied. */
   private previousLayoutTransforms: Map<string, { tx: number; ty: number }> | null = null;
@@ -3749,7 +3749,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    * and runs {@link update}; call this only when a viewport-only refresh is explicitly required.
    */
   public refreshViewportDimensions(): void {
-    if (this.view()) {
+    if (this.view() || !this.initialized) {
       return;
     }
 
@@ -3893,6 +3893,21 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
       this.containerResizeObserver.disconnect();
       this.containerResizeObserver = null;
     }
+    if (this.containerResizeRafId != null) {
+      cancelAnimationFrame(this.containerResizeRafId);
+      this.containerResizeRafId = null;
+    }
+  }
+
+  private scheduleViewportResizeRefresh(): void {
+    if (this.containerResizeRafId != null) {
+      cancelAnimationFrame(this.containerResizeRafId);
+    }
+
+    this.containerResizeRafId = requestAnimationFrame(() => {
+      this.containerResizeRafId = null;
+      this.zone.run(() => this.refreshViewportDimensions());
+    });
   }
 
   private bindContainerResizeEvent(): void {
@@ -3914,6 +3929,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     });
 
     this.containerResizeObserver = new ResizeObserver(() => {
+      this.scheduleViewportResizeRefresh();
       resize$.next();
     });
     this.containerResizeObserver.observe(parent);

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -225,6 +225,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   width: number;
   height: number;
   resizeSubscription: any;
+  private containerResizeObserver: ResizeObserver | null = null;
+  private containerResizeRafId: number | null = null;
   visibilityObserver: VisibilityObserver;
   /** Incremented at the start of each {@link tick}; completion callbacks only emit when this matches. */
   private drawCompleteTickId = 0;
@@ -563,6 +565,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    */
   ngAfterViewInit(): void {
     this.bindWindowResizeEvent();
+    this.bindContainerResizeEvent();
 
     // listen for visibility of the element for hidden by default scenario
     this.visibilityObserver = new VisibilityObserver(this.el, this.zone);
@@ -3742,6 +3745,43 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     };
   }
 
+  /**
+   * Remeasures the parent container and updates SVG viewport size without re-running layout.
+   * Invoked automatically when the parent element resizes (e.g. side panels opening or closing).
+   */
+  public refreshViewportDimensions(): void {
+    if (this.view()) {
+      return;
+    }
+
+    const previousWidth = this.width;
+    const previousHeight = this.height;
+
+    this.basicUpdate();
+
+    if (this.width === previousWidth && this.height === previousHeight) {
+      return;
+    }
+
+    this.dims = calculateViewDimensions({
+      width: this.width,
+      height: this.height
+    });
+
+    this.updateTransform();
+
+    if (this.showMiniMap()) {
+      this.updateMinimap();
+    }
+
+    this.lastFullUpdateWidth = this.width;
+    this.lastFullUpdateHeight = this.height;
+
+    if (this.cd) {
+      this.cd.markForCheck();
+    }
+  }
+
   public basicUpdate(): void {
     const view = this.view();
     if (view) {
@@ -3853,6 +3893,41 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     if (this.resizeSubscription) {
       this.resizeSubscription.unsubscribe();
     }
+    if (this.containerResizeObserver) {
+      this.containerResizeObserver.disconnect();
+      this.containerResizeObserver = null;
+    }
+    if (this.containerResizeRafId != null) {
+      cancelAnimationFrame(this.containerResizeRafId);
+      this.containerResizeRafId = null;
+    }
+  }
+
+  private scheduleContainerResizeRefresh(): void {
+    if (this.containerResizeRafId != null) {
+      return;
+    }
+
+    this.containerResizeRafId = requestAnimationFrame(() => {
+      this.containerResizeRafId = null;
+      this.zone.run(() => this.refreshViewportDimensions());
+    });
+  }
+
+  private bindContainerResizeEvent(): void {
+    if (typeof ResizeObserver === 'undefined' || this.view()) {
+      return;
+    }
+
+    const parent = this.el.nativeElement.parentNode as HTMLElement | null;
+    if (!parent) {
+      return;
+    }
+
+    this.containerResizeObserver = new ResizeObserver(() => {
+      this.scheduleContainerResizeRefresh();
+    });
+    this.containerResizeObserver.observe(parent);
   }
 
   private bindWindowResizeEvent(): void {

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -27,7 +27,7 @@ import {
 import { NgTemplateOutlet } from '@angular/common';
 import { select } from 'd3-selection';
 import * as shape from 'd3-shape';
-import { Observable, Subscription, of, fromEvent as observableFromEvent, Subject } from 'rxjs';
+import { Observable, Subscription, of, Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { identity, scale, smoothMatrix, toSVG, transform, translate } from 'transformation-matrix';
 import { Layout } from '../models/layout.model';
@@ -226,7 +226,6 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   height: number;
   resizeSubscription: any;
   private containerResizeObserver: ResizeObserver | null = null;
-  private containerResizeRafId: number | null = null;
   visibilityObserver: VisibilityObserver;
   /** Incremented at the start of each {@link tick}; completion callbacks only emit when this matches. */
   private drawCompleteTickId = 0;
@@ -564,7 +563,6 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
    * @memberOf GraphComponent
    */
   ngAfterViewInit(): void {
-    this.bindWindowResizeEvent();
     this.bindContainerResizeEvent();
 
     // listen for visibility of the element for hidden by default scenario
@@ -3747,7 +3745,8 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
 
   /**
    * Remeasures the parent container and updates SVG viewport size without re-running layout.
-   * Invoked automatically when the parent element resizes (e.g. side panels opening or closing).
+   * For automatic resize handling, the graph listens to parent container size via ResizeObserver
+   * and runs {@link update}; call this only when a viewport-only refresh is explicitly required.
    */
   public refreshViewportDimensions(): void {
     if (this.view()) {
@@ -3773,9 +3772,6 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     if (this.showMiniMap()) {
       this.updateMinimap();
     }
-
-    this.lastFullUpdateWidth = this.width;
-    this.lastFullUpdateHeight = this.height;
 
     if (this.cd) {
       this.cd.markForCheck();
@@ -3897,21 +3893,6 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
       this.containerResizeObserver.disconnect();
       this.containerResizeObserver = null;
     }
-    if (this.containerResizeRafId != null) {
-      cancelAnimationFrame(this.containerResizeRafId);
-      this.containerResizeRafId = null;
-    }
-  }
-
-  private scheduleContainerResizeRefresh(): void {
-    if (this.containerResizeRafId != null) {
-      return;
-    }
-
-    this.containerResizeRafId = requestAnimationFrame(() => {
-      this.containerResizeRafId = null;
-      this.zone.run(() => this.refreshViewportDimensions());
-    });
   }
 
   private bindContainerResizeEvent(): void {
@@ -3924,20 +3905,17 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
       return;
     }
 
-    this.containerResizeObserver = new ResizeObserver(() => {
-      this.scheduleContainerResizeRefresh();
-    });
-    this.containerResizeObserver.observe(parent);
-  }
-
-  private bindWindowResizeEvent(): void {
-    const source = observableFromEvent(window, 'resize');
-    const subscription = source.pipe(debounceTime(200)).subscribe(e => {
+    const resize$ = new Subject<void>();
+    this.resizeSubscription = resize$.pipe(debounceTime(200), takeUntil(this.destroy$)).subscribe(() => {
       this.update();
       if (this.cd) {
         this.cd.markForCheck();
       }
     });
-    this.resizeSubscription = subscription;
+
+    this.containerResizeObserver = new ResizeObserver(() => {
+      resize$.next();
+    });
+    this.containerResizeObserver.observe(parent);
   }
 }

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -232,6 +232,7 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   private isMouseMoveCalled: boolean = false;
   private containerResizeObserver: ResizeObserver | null = null;
   private containerResizeRafId: number | null = null;
+  private observedContainerDims: { width: number; height: number } | null = null;
   /** Incremented at the start of each {@link tick}; completion callbacks only emit when this matches. */
   private drawCompleteTickId = 0;
   /** True after the first {@link drawComplete} emission for this component instance. */
@@ -3928,9 +3929,30 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
     });
 
     this.containerResizeObserver = new ResizeObserver(() => {
-      this.scheduleViewportResizeRefresh();
-      resize$.next();
+      this.onContainerResizeObserved(resize$);
     });
     this.containerResizeObserver.observe(parent);
+  }
+
+  private onContainerResizeObserved(resize$: Subject<void>): void {
+    const dims = this.getContainerDims();
+    if (!dims) {
+      return;
+    }
+
+    const { width, height } = dims;
+
+    if (!this.observedContainerDims) {
+      this.observedContainerDims = { width, height };
+      return;
+    }
+
+    if (width === this.observedContainerDims.width && height === this.observedContainerDims.height) {
+      return;
+    }
+
+    this.observedContainerDims = { width, height };
+    this.scheduleViewportResizeRefresh();
+    resize$.next();
   }
 }

--- a/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
+++ b/projects/swimlane/ngx-graph/src/lib/graph/graph.component.ts
@@ -221,6 +221,11 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
   height: number;
   resizeSubscription: any;
   visibilityObserver: VisibilityObserver;
+  /** CSS `transform` on `.ngx-graph-outer` during optional layout flair (perspective / rotate). */
+  layoutOuterTransform: string | null = null;
+
+  /** `transform-origin` for {@link layoutOuterTransform} when using rotate pivot modes. */
+  layoutEffectTransformOrigin = '50% 50%';
 
   private _touchLastX = null;
   private _touchLastY = null;
@@ -274,12 +279,6 @@ export class GraphComponent implements OnInit, OnChanges, OnDestroy, AfterViewIn
 
   /** rAF for programmatic viewport pan easing (translation only). */
   private viewportPanAnimRafId: number | null = null;
-
-  /** CSS `transform` on `.ngx-graph-outer` during optional layout flair (perspective / rotate). */
-  private layoutOuterTransform: string | null = null;
-
-  /** `transform-origin` for {@link layoutOuterTransform} when using rotate pivot modes. */
-  private layoutEffectTransformOrigin = '50% 50%';
 
   /** Parsed `translate(tx,ty)` from the graph before a new layout is applied. */
   private previousLayoutTransforms: Map<string, { tx: number; ty: number }> | null = null;

--- a/projects/swimlane/ngx-graph/src/stories/Options.mdx
+++ b/projects/swimlane/ngx-graph/src/stories/Options.mdx
@@ -93,7 +93,7 @@ See **Example / NgxGraphDagreLayoutTransition**, **Example / NgxGraphTranslateOn
 
 ## Dimensions
 
-The graph component accepts a `view` input, which is an array with two numeric elements: `[width, height]` in pixels. If the `view` input is ommited or undefined, the graph will resize itself to fit the parent container.
+The graph component accepts a `view` input, which is an array with two numeric elements: `[width, height]` in pixels. If the `view` input is ommited or undefined, the graph will resize itself to fit the parent container. When `view` is omitted, the graph observes its parent element with `ResizeObserver` and runs `update()` on size changes (debounced 200ms), including relayout — the same behavior as the previous window-resize listener, but triggered by parent container size instead of the browser window.
 
 [[note | Note]]
 | The parent container must have a non-zero height defined, and no padding in order for the graph to properly fit its size.

--- a/projects/swimlane/ngx-graph/src/stories/Options.mdx
+++ b/projects/swimlane/ngx-graph/src/stories/Options.mdx
@@ -93,7 +93,7 @@ See **Example / NgxGraphDagreLayoutTransition**, **Example / NgxGraphTranslateOn
 
 ## Dimensions
 
-The graph component accepts a `view` input, which is an array with two numeric elements: `[width, height]` in pixels. If the `view` input is ommited or undefined, the graph will resize itself to fit the parent container. When `view` is omitted, the graph observes its parent element with `ResizeObserver` and runs `update()` on size changes (debounced 200ms), including relayout — the same behavior as the previous window-resize listener, but triggered by parent container size instead of the browser window.
+The graph component accepts a `view` input, which is an array with two numeric elements: `[width, height]` in pixels. If the `view` input is ommited or undefined, the graph will resize itself to fit the parent container. When `view` is omitted, the graph observes its parent element with `ResizeObserver`. While the parent is resizing (e.g. a side panel CSS transition), the SVG viewport updates each animation frame without re-running layout; when resize settles, `update()` runs (debounced 200ms) for full relayout including `autoZoom` / `autoCenter` — the same end-state behavior as the previous window-resize listener, but driven by parent container size.
 
 [[note | Note]]
 | The parent container must have a non-zero height defined, and no padding in order for the graph to properly fit its size.


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Library relies on window resize, which does not effectively draw the graph when the graph's container is the node being resized.

**What is the new behavior?**

Deprecate window resize and use container resize instead.

**Does this PR introduce a breaking change?** (check one with "x")
- [X] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Browsers older than ~2020 will no longer be supported.

**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking resize behavior may affect layouts that depended on window resize without parent size changes; core graph lifecycle and layout paths are touched but heavily tested.
> 
> **Overview**
> **GraphComponent** no longer listens to **`window` `resize`**. When **`view`** is omitted, it observes the **parent element** with **`ResizeObserver`** so flex layouts, side panels, and similar container resizes trigger the same end behavior as before (debounced **`update()`** at 200ms, including **`autoZoom`** / **`autoCenter`**).
> 
> While the parent is still changing size, **`refreshViewportDimensions()`** updates SVG width/height each animation frame (coalesced to one rAF) **without** re-running layout; after resize settles, the debounced **`update()`** runs a full relayout. The first observe callback only records a baseline so it does not fire an extra **`update()`** or disturb in-flight async layouts. With **`[view]`** set, container observation is skipped (unchanged).
> 
> **Migration:** automatic resize now depends on a parent whose dimensions track layout; apps that only resized the window while the graph’s box stayed fixed may need to resize the graph’s container or call **`update()`** / **`refreshViewportDimensions()`** explicitly. **`ResizeObserver`** is required (roughly post-2020 browsers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d904fb77e86265d2bbf7c6c89fe0a1be57ca994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->