### PR TITLE
(release): 12.0.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 12.0.0-alpha.6
+
 - Enhancement: During animated parent resizes, the SVG viewport syncs each animation frame via `refreshViewportDimensions()` (no layout); debounced `update()` still runs 200ms after resize settles for full relayout.
 - Breaking: `GraphComponent` no longer listens to `window` `resize`; automatic resize requires a parent element whose size reflects layout changes. When `[view]` is set, container resize is not observed (unchanged dimension source).
 - Fix: Graph resizes when its parent container changes size (e.g. side panels, flex layouts) via `ResizeObserver`, matching the previous window-resize `update()` behavior including layout.

--- a/projects/swimlane/ngx-graph/package.json
+++ b/projects/swimlane/ngx-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-graph",
-  "version": "12.0.0-alpha.5",
+  "version": "12.0.0-alpha.6",
   "description": "Graph visualization for angular",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


- Enhancement: During animated parent resizes, the SVG viewport syncs each animation frame via `refreshViewportDimensions()` (no layout); debounced `update()` still runs 200ms after resize settles for full relayout.
- Breaking: `GraphComponent` no longer listens to `window` `resize`; automatic resize requires a parent element whose size reflects layout changes. When `[view]` is set, container resize is not observed (unchanged dimension source).
- Fix: Graph resizes when its parent container changes size (e.g. side panels, flex layouts) via `ResizeObserver`, matching the previous window-resize `update()` behavior including layout.




**Does this PR introduce a breaking change?** (check one with "x")
- [X] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and changelog updates; no runtime code changes in this diff.
> 
> **Overview**
> Release **12.0.0-alpha.6** for `@swimlane/ngx-graph`: bumps `projects/swimlane/ngx-graph/package.json` from `12.0.0-alpha.5` and adds a **12.0.0-alpha.6** section to `CHANGELOG.md`.
> 
> The changelog documents behavior shipped in this alpha (not new edits in this diff): **ResizeObserver** on the graph container so parent size changes trigger relayout; per-frame **`refreshViewportDimensions()`** during animated resizes with a debounced **`update()`** after settle; and removal of **`window` `resize`** listening (breaking unless the parent element tracks layout size; **`[view]`** still skips container observation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 167c4a946743e4f33ac9c3f328b9798a50b84350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->