### PR TITLE
(release): 12.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## HEAD (unreleased)
 
+## 12.0.0
+
+- Enhancement: `setViewportInteraction` allows toggling pan, drag, and zoom in one imperative method.
+- Enhancement: During animated parent resizes, the SVG viewport syncs each animation frame via `refreshViewportDimensions()` (no layout); debounced `update()` still runs 200ms after resize settles for full relayout.
+- Fix: Graph resizes when its parent container changes size (e.g. side panels, flex layouts) via `ResizeObserver`, matching the previous window-resize `update()` behavior including layout.
+- Fix: `drawComplete` and `stateChange` (`Output`) now emit from tick finalization only when the internal graph model and bound link paths are ready (removed `hasDims()` polling in `ngOnInit`). `drawComplete` still fires once on first ready draw; `Output` fires on every subsequent ready tick.
+- Fix: `hasClusterDims()` and `hasCompoundNodeDims()` mirror `hasNodeDims()` when the graph model list is empty (respect bound inputs). `hasDims()` checks dimensions only for the grouping input that is bound (clusters or compound nodes — mutually exclusive modes).
+- Fix: possible console error when nodes or edges are not available during ngOnChanges.
+- Fix: Suppress layout animation on zoom.
+- Fix: Tests should honor BROWSER env.
+- Fix: `CompoundNode` and `Cluster` should transition size and position when animations are enabled.
+- Fix: `tick()` assigns `oldNodes` / `oldClusters` / `oldCompoundNodes` from the current graph **before** the post-tick `requestAnimationFrame`, so `[class.old-node]` is consistent for newly added ids on the same tick (fixes flash on zoom with `mode: 'tween'`, including additive + `snapAddedNodeIds`).
+- Fix: `#nodeTemplate` / `#linkTemplate` / `#clusterTemplate` outlets reuse a stable `ngTemplateOutletContext` object per graph id (pruned each `tick()`) so consumer templates (e.g. tooltips) are not torn down and recreated on viewport-only updates such as zoom.
+- Fix: `applyVisualContinuityBeforeLayout` clears `hidden` on nodes/clusters/compound nodes whose id existed in the prior graph so host-owned `[nodes]` references do not keep stale `hidden: true` after `tick()` ran on a different layout object graph (reduces template blink when `update()` runs again).
+- Fix: Observable layouts (Cola, D3 force) faster than `afterNextRender`—superseded passes repaint link paths from the current model without full `redrawLines` so layout morph is not cancelled.
+- Fix: Layout morph keeps `oldLine` / `oldTextPath` on paths that are not resampled-tweening until the tween ends instead of snapping to the new route early.
+- Fix: Drag `updateEdge` for Dagre and DagreCluster uses orientation-aware paths aligned with DagreNodesOnly.
+- Chore: Update Storybook with documentation, examples.
+
+- Breaking: `GraphComponent` is now a standalone component built on signal APIs (`input`, `output`, `model`, `contentChild`, `viewChildren`) instead of decorator-based `@Input` / `@Output` and classic queries. The published `NgxGraphModule` and `GraphModule` wrappers are still there so existing NgModule-based applications can import the graph as before, but those modules are deprecated; new code should import `GraphComponent` (and add it to the consuming component or route `imports` array) the same way you would any other standalone piece.
+- Breaking: From TypeScript, inputs behave like signal readers: for example, read the current node list with `graph.nodes()` rather than `graph.nodes`. The `layout`, `curve`, and `activeEntries` bindings use `model()` where the graph needs to write back internally; consumers generally keep using normal property bindings, while code inside the component updates via `.set()`.
+- Breaking: Outputs are `OutputRef` values, not `EventEmitter`, so they do not offer `.pipe()`. To keep using RxJS operators, turn an output into an observable with `outputToObservable` from `@angular/core/rxjs-interop` (in an appropriate injection context), or subscribe to the ref directly. Payload types (such as `NgxGraphStateChangeEvent`) are unchanged; only the subscription shape differs.
+- Breaking: `@ViewChildren` / `@ContentChild` style access is replaced with signal query functions, so in component code you call `graph.linkElements()` (or the other query methods) instead of keeping a `QueryList` on a property.
+- Breaking: The in-component `animations: [ trigger(...) ]` definition was removed. Enter styling on the root now uses the framework’s `animate.enter` class binding together with keyframes in the graph stylesheet, which replaces the old opacity `:enter` transition and avoids the deprecated `trigger` API. Angular does not support mixing the legacy `animations` metadata and `animate.enter` / `animate.leave` on the same component. The old `[@.disabled]` host binding for the legacy tree is also gone; it was scoped to the previous animation system and did not drive node positions, but projected templates that relied on that subtree being disabled for their own `[@...]` triggers may need a different approach.
+- Breaking: Optional viewport inputs `zoomLevel`, `panOffsetX`, and `panOffsetY` are now signal inputs wired through `effect()` to `zoomTo` and `panTo`, so the graph no longer assigns those via a property setter, and the effects run when the parent binding’s value actually changes. If a parent expression changes on every data refresh, you may see extra viewport updates; binding stable values (or leaving these inputs unset) matches the old mental model. Automatic fit and centering still come from the documented `autoZoom`, `autoCenter`, and `zoomToFit$` behavior. If you use `transitionAfterChanges` with full-scope layout morph, whether the post-tick block runs `zoomToFit` or `center` can differ from the additive or instant paths, as before.
+- Breaking: If node.position is undefined, could cause a template error, ensure node has position via layout or proper handling in template.
+- Breaking: When using new transitions, any condition wrappers in Angular templates for node and edges could interfere with animations if the condition wraps a container node.
+- Breaking: `draggingEnabled`, `panningEnabled` renamed to `enableDrag` and `enablePan`.
+- Breaking: `GraphComponent` no longer listens to `window` `resize`; automatic resize requires a parent element whose size reflects layout changes. When `[view]` is set, container resize is not observed (unchanged dimension source).
+
 ## 12.0.0-alpha.6
 
 - Enhancement: During animated parent resizes, the SVG viewport syncs each animation frame via `refreshViewportDimensions()` (no layout); debounced `update()` still runs 200ms after resize settles for full relayout.
@@ -25,7 +55,6 @@
 ## 12.0.0-alpha.2
 
 - Breaking: `draggingEnabled`, `panningEnabled` renamed to `enableDrag` and `enablePan`.
-- Breaking: `draggingEnabled`, `panningEnabled`, `enableZoom` converted to model.
 - Enhancement: `setViewportInteraction` allows toggling pan, drag, and zoom in one imperative method.
 - Fix: `CompoundNode` and `Cluster` should transition size and position when animations are enabled.
 - Fix: `tick()` assigns `oldNodes` / `oldClusters` / `oldCompoundNodes` from the current graph **before** the post-tick `requestAnimationFrame`, so `[class.old-node]` is consistent for newly added ids on the same tick (fixes flash on zoom with `mode: 'tween'`, including additive + `snapAddedNodeIds`).

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@storybook/angular": "10.2.0",
     "@storybook/builder-webpack5": "10.2.0",
     "@swimlane/eslint-config": "^2.0.0",
-    "@swimlane/prettier-config-swimlane": "4.0.0-alpha.0",
+    "@swimlane/prettier-config-swimlane": "4.0.0",
     "@types/d3-array": "^3",
     "@types/d3-ease": "^1.0.8",
     "@types/d3-scale": "^4",

--- a/projects/swimlane/ngx-graph/package.json
+++ b/projects/swimlane/ngx-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-graph",
-  "version": "12.0.0-alpha.6",
+  "version": "12.0.0",
   "description": "Graph visualization for angular",
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4612,12 +4612,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swimlane/prettier-config-swimlane@npm:4.0.0-alpha.0":
-  version: 4.0.0-alpha.0
-  resolution: "@swimlane/prettier-config-swimlane@npm:4.0.0-alpha.0"
+"@swimlane/prettier-config-swimlane@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@swimlane/prettier-config-swimlane@npm:4.0.0"
   peerDependencies:
     prettier: 3.3.3
-  checksum: 10c0/f552c95628010d6f1aaa8dbd094136b22fe1f643085c8e5b7b64443c741fb5287cecdcb426f0d7c47db57a7b562d4c698357532fb45c6b402b91088050a86f3d
+  checksum: 10c0/e0a99fd4f71e1c4bc6cf9e3e5aa9ad0c82004f1b2e0ff3eeabf64b380faf230fb47db8c7858c09b50c3d90741b8e289ab92a7b97234115e468243b565bc5ab41
   languageName: node
   linkType: hard
 
@@ -12871,7 +12871,7 @@ __metadata:
     "@storybook/angular": "npm:10.2.0"
     "@storybook/builder-webpack5": "npm:10.2.0"
     "@swimlane/eslint-config": "npm:^2.0.0"
-    "@swimlane/prettier-config-swimlane": "npm:4.0.0-alpha.0"
+    "@swimlane/prettier-config-swimlane": "npm:4.0.0"
     "@types/d3-array": "npm:^3"
     "@types/d3-ease": "npm:^1.0.8"
     "@types/d3-scale": "npm:^4"


### PR DESCRIPTION
## 12.0.0

- Enhancement: `setViewportInteraction` allows toggling pan, drag, and zoom in one imperative method.
- Enhancement: During animated parent resizes, the SVG viewport syncs each animation frame via `refreshViewportDimensions()` (no layout); debounced `update()` still runs 200ms after resize settles for full relayout.
- Fix: Graph resizes when its parent container changes size (e.g. side panels, flex layouts) via `ResizeObserver`, matching the previous window-resize `update()` behavior including layout.
- Fix: `drawComplete` and `stateChange` (`Output`) now emit from tick finalization only when the internal graph model and bound link paths are ready (removed `hasDims()` polling in `ngOnInit`). `drawComplete` still fires once on first ready draw; `Output` fires on every subsequent ready tick.
- Fix: `hasClusterDims()` and `hasCompoundNodeDims()` mirror `hasNodeDims()` when the graph model list is empty (respect bound inputs). `hasDims()` checks dimensions only for the grouping input that is bound (clusters or compound nodes — mutually exclusive modes).
- Fix: possible console error when nodes or edges are not available during ngOnChanges.
- Fix: Suppress layout animation on zoom.
- Fix: Tests should honor BROWSER env.
- Fix: `CompoundNode` and `Cluster` should transition size and position when animations are enabled.
- Fix: `tick()` assigns `oldNodes` / `oldClusters` / `oldCompoundNodes` from the current graph **before** the post-tick `requestAnimationFrame`, so `[class.old-node]` is consistent for newly added ids on the same tick (fixes flash on zoom with `mode: 'tween'`, including additive + `snapAddedNodeIds`).
- Fix: `#nodeTemplate` / `#linkTemplate` / `#clusterTemplate` outlets reuse a stable `ngTemplateOutletContext` object per graph id (pruned each `tick()`) so consumer templates (e.g. tooltips) are not torn down and recreated on viewport-only updates such as zoom.
- Fix: `applyVisualContinuityBeforeLayout` clears `hidden` on nodes/clusters/compound nodes whose id existed in the prior graph so host-owned `[nodes]` references do not keep stale `hidden: true` after `tick()` ran on a different layout object graph (reduces template blink when `update()` runs again).
- Fix: Observable layouts (Cola, D3 force) faster than `afterNextRender`—superseded passes repaint link paths from the current model without full `redrawLines` so layout morph is not cancelled.
- Fix: Layout morph keeps `oldLine` / `oldTextPath` on paths that are not resampled-tweening until the tween ends instead of snapping to the new route early.
- Fix: Drag `updateEdge` for Dagre and DagreCluster uses orientation-aware paths aligned with DagreNodesOnly.
- Chore: Update Storybook with documentation, examples.

- Breaking: `GraphComponent` is now a standalone component built on signal APIs (`input`, `output`, `model`, `contentChild`, `viewChildren`) instead of decorator-based `@Input` / `@Output` and classic queries. The published `NgxGraphModule` and `GraphModule` wrappers are still there so existing NgModule-based applications can import the graph as before, but those modules are deprecated; new code should import `GraphComponent` (and add it to the consuming component or route `imports` array) the same way you would any other standalone piece.
- Breaking: From TypeScript, inputs behave like signal readers: for example, read the current node list with `graph.nodes()` rather than `graph.nodes`. The `layout`, `curve`, and `activeEntries` bindings use `model()` where the graph needs to write back internally; consumers generally keep using normal property bindings, while code inside the component updates via `.set()`.
- Breaking: Outputs are `OutputRef` values, not `EventEmitter`, so they do not offer `.pipe()`. To keep using RxJS operators, turn an output into an observable with `outputToObservable` from `@angular/core/rxjs-interop` (in an appropriate injection context), or subscribe to the ref directly. Payload types (such as `NgxGraphStateChangeEvent`) are unchanged; only the subscription shape differs.
- Breaking: `@ViewChildren` / `@ContentChild` style access is replaced with signal query functions, so in component code you call `graph.linkElements()` (or the other query methods) instead of keeping a `QueryList` on a property.
- Breaking: The in-component `animations: [ trigger(...) ]` definition was removed. Enter styling on the root now uses the framework’s `animate.enter` class binding together with keyframes in the graph stylesheet, which replaces the old opacity `:enter` transition and avoids the deprecated `trigger` API. Angular does not support mixing the legacy `animations` metadata and `animate.enter` / `animate.leave` on the same component. The old `[@.disabled]` host binding for the legacy tree is also gone; it was scoped to the previous animation system and did not drive node positions, but projected templates that relied on that subtree being disabled for their own `[@...]` triggers may need a different approach.
- Breaking: Optional viewport inputs `zoomLevel`, `panOffsetX`, and `panOffsetY` are now signal inputs wired through `effect()` to `zoomTo` and `panTo`, so the graph no longer assigns those via a property setter, and the effects run when the parent binding’s value actually changes. If a parent expression changes on every data refresh, you may see extra viewport updates; binding stable values (or leaving these inputs unset) matches the old mental model. Automatic fit and centering still come from the documented `autoZoom`, `autoCenter`, and `zoomToFit$` behavior. If you use `transitionAfterChanges` with full-scope layout morph, whether the post-tick block runs `zoomToFit` or `center` can differ from the additive or instant paths, as before.
- Breaking: If node.position is undefined, could cause a template error, ensure node has position via layout or proper handling in template.
- Breaking: When using new transitions, any condition wrappers in Angular templates for node and edges could interfere with animations if the condition wraps a container node.
- Breaking: `draggingEnabled`, `panningEnabled` renamed to `enableDrag` and `enablePan`.
- Breaking: `GraphComponent` no longer listens to `window` `resize`; automatic resize requires a parent element whose size reflects layout changes. When `[view]` is set, container resize is not observed (unchanged dimension source).



**Does this PR introduce a breaking change?** (check one with "x")
- [X] Yes
- [ ] No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and dependency lockfile updates only; consumer-facing behavior is documented in CHANGELOG, not altered by this diff.
> 
> **Overview**
> **Release cut for `@swimlane/ngx-graph` 12.0.0** — no library source changes in this diff; it finalizes what ships in the stable tag.
> 
> The published package version moves from `12.0.0-alpha.6` to **`12.0.0`**. **CHANGELOG** adds a consolidated **`## 12.0.0`** section that rolls up enhancements, fixes, and breaking changes from the alpha line (signal-based standalone `GraphComponent`, renamed pan/drag inputs, `ResizeObserver` instead of window resize, animation and layout-morph fixes, etc.). A stale alpha note about `enableZoom` as a model input is removed from the alpha.2 history.
> 
> Dev tooling only: **`@swimlane/prettier-config-swimlane`** is bumped from `4.0.0-alpha.0` to **`4.0.0`** in the root `package.json` and **`yarn.lock`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68dde1d95601ff5668261b62813d3d018644800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->