### PR TITLE
chore: remove unused @angular/animations dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@angular/animations": "~21.1.1",
     "@angular/cdk": "~20.0.3",
     "@angular/common": "~21.1.1",
     "@angular/compiler": "~21.1.1",

--- a/projects/swimlane/ngx-graph/package.json
+++ b/projects/swimlane/ngx-graph/package.json
@@ -30,7 +30,6 @@
   },
   "homepage": "https://github.com/swimlane/ngx-graph#readme",
   "peerDependencies": {
-    "@angular/animations": "19.x || 20.x || 21.x",
     "@angular/common": "19.x || 20.x || 21.x",
     "@angular/core": "19.x || 20.x || 21.x",
     "@angular/cdk": "19.x || 20.x || 21.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,17 +520,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/animations@npm:~21.1.1":
-  version: 21.1.1
-  resolution: "@angular/animations@npm:21.1.1"
-  dependencies:
-    tslib: "npm:^2.3.0"
-  peerDependencies:
-    "@angular/core": 21.1.1
-  checksum: 10c0/60dd58033b6c7370670c6ac5d4d9d4eb5986d94367d4070b424fae1603d6092aa62ed39e52fa48beb66d2ef9a33d61495a32052b9a60047d9e3e67c950522fb8
-  languageName: node
-  linkType: hard
-
 "@angular/build@npm:21.1.1":
   version: 21.1.1
   resolution: "@angular/build@npm:21.1.1"
@@ -12848,7 +12837,6 @@ __metadata:
     "@angular-eslint/eslint-plugin-template": "npm:~20.1.1"
     "@angular-eslint/schematics": "npm:~20.1.1"
     "@angular-eslint/template-parser": "npm:~20.1.1"
-    "@angular/animations": "npm:~21.1.1"
     "@angular/cdk": "npm:~20.0.3"
     "@angular/cli": "npm:21.1.1"
     "@angular/common": "npm:~21.1.1"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
`@angular/animations` is listed as an explicit dependency in the root `package.json` and as a peer dependency in the library's `package.json`, but is not used anywhere in the library. It is also deprecated.

**What is the new behavior?**
`@angular/animations` is removed from both the root `package.json` and the library's `projects/swimlane/ngx-graph/package.json` peer dependencies, along with `yarn.lock`.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
`yarn why @angular/animations` confirms no other package depends on it transitively.
`package-lock.json` was not modified as this project uses yarn as its package manager. It was unclear whether it needed to be updated as well. Open to guidance on this.
fix https://github.com/swimlane/ngx-graph/issues/635